### PR TITLE
93 netmanaget deploy task creation gets stuck

### DIFF
--- a/node-net-manager/NetManager.go
+++ b/node-net-manager/NetManager.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"github.com/gorilla/mux"
 	"github.com/tkanos/gonfig"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
@@ -25,6 +25,11 @@ type undeployRequest struct {
 
 type registerRequest struct {
 	ClientID string `json:"client_id"`
+}
+
+type DeployResponse struct {
+	ServiceName string `json:"serviceName"`
+	NsAddress   string `json:"nsAddress"`
 }
 
 type netConfiguration struct {
@@ -71,7 +76,7 @@ func containerUndeploy(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	reqBody, _ := ioutil.ReadAll(request.Body)
+	reqBody, _ := io.ReadAll(request.Body)
 	var requestStruct undeployRequest
 	err := json.Unmarshal(reqBody, &requestStruct)
 	if err != nil {
@@ -141,22 +146,41 @@ func containerDeploy(writer http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	reqBody, _ := ioutil.ReadAll(request.Body)
+	reqBody, _ := io.ReadAll(request.Body)
 	log.Println("ReqBody received :", reqBody)
-	var requestStruct handlers.ContainerDeployRequest
-	err := json.Unmarshal(reqBody, &requestStruct)
+	var deployTask handlers.ContainerDeployTask
+	err := json.Unmarshal(reqBody, &deployTask)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
 	}
-	requestStruct.PublicAddr = Configuration.NodePublicAddress
-	requestStruct.PublicPort = Configuration.NodePublicPort
-	requestStruct.Env = Env
-	requestStruct.Writer = &writer
-	requestStruct.Finish = make(chan bool, 0)
-	log.Println(requestStruct)
+	deployTask.PublicAddr = Configuration.NodePublicAddress
+	deployTask.PublicPort = Configuration.NodePublicPort
+	deployTask.Env = Env
+	deployTask.Writer = &writer
+	deployTask.Finish = make(chan handlers.TaskReady)
 
-	handlers.NewDeployTaskQueue().NewTask(&requestStruct)
-	<-requestStruct.Finish
+	logger.DebugLogger().Println(deployTask)
+	handlers.NewDeployTaskQueue().NewTask(&deployTask)
+
+	result := <-deployTask.Finish
+	if result.Err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	//if deploy succesfull -> answer the caller
+	response := DeployResponse{
+		ServiceName: deployTask.ServiceName,
+		NsAddress:   result.IP.String(),
+	}
+
+	logger.InfoLogger().Println("Response to /container/deploy: ", response)
+
+	writer.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(writer).Encode(response)
+	if err != nil {
+		writer.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 /*
@@ -174,7 +198,7 @@ Response: 200 or Failure code
 func register(writer http.ResponseWriter, request *http.Request) {
 	log.Println("Received HTTP request - /register ")
 
-	reqBody, _ := ioutil.ReadAll(request.Body)
+	reqBody, _ := io.ReadAll(request.Body)
 	var requestStruct registerRequest
 	err := json.Unmarshal(reqBody, &requestStruct)
 	if err != nil {

--- a/node-net-manager/NetManager.go
+++ b/node-net-manager/NetManager.go
@@ -221,7 +221,7 @@ func register(writer http.ResponseWriter, request *http.Request) {
 	WorkerID = requestStruct.ClientID
 
 	//initialize mqtt connection to the broker
-	mqtt.InitMqtt(requestStruct.ClientID, Configuration.ClusterUrl, Configuration.ClusterMqttPort)
+	mqtt.InitNetMqttClient(requestStruct.ClientID, Configuration.ClusterUrl, Configuration.ClusterMqttPort)
 
 	//initialize the proxy tunnel
 	Proxy = proxy.New()

--- a/node-net-manager/env/EnvironmentManager.go
+++ b/node-net-manager/env/EnvironmentManager.go
@@ -256,7 +256,7 @@ func (env *Environment) createVethsPairAndAttachToBridge(sname string, mtu int) 
 	logger.DebugLogger().Println("Retrieving current bridge ")
 	bridge, err := netlink.LinkByName(env.config.HostBridgeName)
 	if err != nil {
-		logger.ErrorLogger().Println("Error retrieving current bridge: %v", err)
+		logger.ErrorLogger().Println("Error retrieving current bridge: ", err)
 		return nil, err
 	}
 	logger.DebugLogger().Println("Retrieved current bridge")

--- a/node-net-manager/handlers/deployment.go
+++ b/node-net-manager/handlers/deployment.go
@@ -62,7 +62,7 @@ func (t *deployTaskQueue) taskExecutor() {
 			//deploy the network stack in the container
 			addr, err := deploymentHandler(task)
 			if err != nil {
-				logger.ErrorLogger().Println("[ERROR]: %v", err)
+				logger.ErrorLogger().Println("[ERROR]: ", err)
 			}
 			task.Finish <- TaskReady{
 				IP:  addr,

--- a/node-net-manager/mqtt/MqttJobUpdates.go
+++ b/node-net-manager/mqtt/MqttJobUpdates.go
@@ -117,5 +117,5 @@ func MqttIsInterestRegistered(jobName string) bool {
 func cleanInterestTowardsJob(jobName string) {
 	request := mqttInterestDeregisterRequest{Appname: jobName}
 	jsonreq, _ := json.Marshal(request)
-	PublishToBroker("interest/remove", string(jsonreq))
+	_ = PublishToBroker("interest/remove", string(jsonreq))
 }

--- a/node-net-manager/mqtt/MqttMainClient.go
+++ b/node-net-manager/mqtt/MqttMainClient.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"NetManager/logger"
 	"fmt"
 	"github.com/eclipse/paho.mqtt.golang"
 	"log"
@@ -92,7 +93,7 @@ func runMqttClient(opts *mqtt.ClientOptions) {
 func PublishToBroker(topic string, payload string) error {
 	mqttWriteMutex.Lock()
 	defer mqttWriteMutex.Unlock()
-	log.Printf("MQTT - publish to - %s - the payload - %s", topic, payload)
+	logger.DebugLogger().Printf("MQTT - publish to - %s - the payload - %s", topic, payload)
 	token := mainMqttClient.Publish(fmt.Sprintf("nodes/%s/net/%s", clientID, topic), 1, false, payload)
 	if token.WaitTimeout(time.Second*5) && token.Error() != nil {
 		log.Printf("ERROR: MQTT PUBLISH: %s", token.Error())

--- a/node-net-manager/mqtt/MqttMainClient.go
+++ b/node-net-manager/mqtt/MqttMainClient.go
@@ -89,12 +89,14 @@ func runMqttClient(opts *mqtt.ClientOptions) {
 	}
 }
 
-func PublishToBroker(topic string, payload string) {
+func PublishToBroker(topic string, payload string) error {
 	mqttWriteMutex.Lock()
 	defer mqttWriteMutex.Unlock()
 	log.Printf("MQTT - publish to - %s - the payload - %s", topic, payload)
 	token := mainMqttClient.Publish(fmt.Sprintf("nodes/%s/net/%s", clientID, topic), 1, false, payload)
 	if token.WaitTimeout(time.Second*5) && token.Error() != nil {
 		log.Printf("ERROR: MQTT PUBLISH: %s", token.Error())
+		return token.Error()
 	}
+	return nil
 }

--- a/node-net-manager/mqtt/MqttMainClient.go
+++ b/node-net-manager/mqtt/MqttMainClient.go
@@ -10,94 +10,124 @@ import (
 	"time"
 )
 
-var TOPICS = make(map[string]mqtt.MessageHandler)
+var initMqttClient sync.Once
 
-var clientID = ""
-var mainMqttClient mqtt.Client
-var BrokerUrl = ""
-var BrokerPort = ""
-
-var mqttWriteMutex sync.Mutex
-
-var tableQueryRequestCache *TableQueryRequestCache
-
-var messagePubHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
-	log.Printf("DEBUG - Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
+type NetMqttClient struct {
+	topics                 map[string]mqtt.MessageHandler
+	clientID               string
+	mainMqttClient         mqtt.Client
+	brokerUrl              string
+	brokerPort             string
+	mqttWriteMutex         *sync.Mutex
+	mqttTopicsMutex        *sync.RWMutex
+	tableQueryRequestCache *TableQueryRequestCache
 }
 
-var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
-	log.Println("Connected to the MQTT broker")
+var netMqttClient NetMqttClient
 
-	topicsQosMap := make(map[string]byte)
-	for key, _ := range TOPICS {
-		topicsQosMap[key] = 1
-	}
-
-	//subscribe to all the topics
-	tqtoken := client.SubscribeMultiple(topicsQosMap, subscribeHandlerDispatcher)
-	tqtoken.Wait()
-	log.Printf("Subscribed to topics \n")
-
-}
-
-var subscribeHandlerDispatcher = func(client mqtt.Client, msg mqtt.Message) {
-	for key, handler := range TOPICS {
-		if strings.Contains(msg.Topic(), key) {
-			handler(client, msg)
+func InitNetMqttClient(clientid string, brokerurl string, brokerport string) *NetMqttClient {
+	initMqttClient.Do(func() {
+		netMqttClient = NetMqttClient{
+			topics:                 make(map[string]mqtt.MessageHandler),
+			clientID:               clientid,
+			mainMqttClient:         nil,
+			brokerUrl:              brokerurl,
+			brokerPort:             brokerport,
+			mqttWriteMutex:         &sync.Mutex{},
+			mqttTopicsMutex:        &sync.RWMutex{},
+			tableQueryRequestCache: GetTableQueryRequestCacheInstance(),
 		}
-	}
+
+		var messageDefaultHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
+			log.Printf("DEBUG - Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
+		}
+
+		var subscribeHandlerDispatcher = func(client mqtt.Client, msg mqtt.Message) {
+			handlerlist := make([]mqtt.MessageHandler, 0)
+			netMqttClient.mqttTopicsMutex.RLock()
+			for key, handler := range netMqttClient.topics {
+				if strings.Contains(msg.Topic(), key) {
+					handlerlist = append(handlerlist, handler)
+				}
+			}
+			netMqttClient.mqttTopicsMutex.RUnlock()
+			for _, handler := range handlerlist {
+				handler(client, msg)
+			}
+		}
+
+		var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
+			log.Println("Connected to the MQTT broker")
+
+			topicsQosMap := make(map[string]byte)
+			for key, _ := range netMqttClient.topics {
+				topicsQosMap[key] = 1
+			}
+
+			//subscribe to all the topics
+			tqtoken := client.SubscribeMultiple(topicsQosMap, subscribeHandlerDispatcher)
+			tqtoken.Wait()
+			log.Printf("Subscribed to topics \n")
+
+		}
+
+		var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err error) {
+			log.Printf("Connect lost: %v", err)
+		}
+
+		netMqttClient.topics[fmt.Sprintf("nodes/%s/net/tablequery/result", netMqttClient.clientID)] =
+			netMqttClient.tableQueryRequestCache.TablequeryResultMqttHandler
+		netMqttClient.topics[fmt.Sprintf("nodes/%s/net/subnetwork/result", netMqttClient.clientID)] =
+			subnetworkAssignmentMqttHandler
+
+		opts := mqtt.NewClientOptions()
+		opts.AddBroker(fmt.Sprintf("tcp://%s:%s", netMqttClient.brokerUrl, netMqttClient.brokerPort))
+		opts.SetClientID(clientid)
+		opts.SetUsername("")
+		opts.SetPassword("")
+		opts.SetDefaultPublishHandler(messageDefaultHandler)
+		opts.OnConnect = connectHandler
+		opts.OnConnectionLost = connectLostHandler
+
+		netMqttClient.runMqttClient(opts)
+	})
+	return &netMqttClient
 }
 
-var connectLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err error) {
-	log.Printf("Connect lost: %v", err)
+func GetNetMqttClient() *NetMqttClient {
+	return &netMqttClient
 }
 
-func InitMqtt(clientid string, brokerurl string, brokerport string) {
-
-	if clientID != "" {
-		log.Printf("Mqtt already initialized no need for any further initialization")
-		return
-	}
-
-	BrokerPort = brokerport
-	BrokerUrl = brokerurl
-
-	//platform's assigned client ID
-	clientID = clientid
-	tableQueryRequestCache = GetTableQueryRequestCacheInstance()
-
-	TOPICS[fmt.Sprintf("nodes/%s/net/tablequery/result", clientID)] =
-		tableQueryRequestCache.TablequeryResultMqttHandler
-	TOPICS[fmt.Sprintf("nodes/%s/net/subnetwork/result", clientID)] =
-		subnetworkAssignmentMqttHandler
-
-	opts := mqtt.NewClientOptions()
-	opts.AddBroker(fmt.Sprintf("tcp://%s:%s", BrokerUrl, BrokerPort))
-	opts.SetClientID(clientid)
-	opts.SetUsername("")
-	opts.SetPassword("")
-	opts.SetDefaultPublishHandler(messagePubHandler)
-	opts.OnConnect = connectHandler
-	opts.OnConnectionLost = connectLostHandler
-
-	runMqttClient(opts)
-}
-
-func runMqttClient(opts *mqtt.ClientOptions) {
-	mainMqttClient = mqtt.NewClient(opts)
-	if token := mainMqttClient.Connect(); token.Wait() && token.Error() != nil {
+func (netmqtt *NetMqttClient) runMqttClient(opts *mqtt.ClientOptions) {
+	netmqtt.mainMqttClient = mqtt.NewClient(opts)
+	if token := netmqtt.mainMqttClient.Connect(); token.Wait() && token.Error() != nil {
 		panic(token.Error())
 	}
 }
 
-func PublishToBroker(topic string, payload string) error {
-	mqttWriteMutex.Lock()
-	defer mqttWriteMutex.Unlock()
+func (netmqtt *NetMqttClient) PublishToBroker(topic string, payload string) error {
+	netmqtt.mqttWriteMutex.Lock()
+	defer netmqtt.mqttWriteMutex.Unlock()
 	logger.DebugLogger().Printf("MQTT - publish to - %s - the payload - %s", topic, payload)
-	token := mainMqttClient.Publish(fmt.Sprintf("nodes/%s/net/%s", clientID, topic), 1, false, payload)
+	token := netmqtt.mainMqttClient.Publish(fmt.Sprintf("nodes/%s/net/%s", netmqtt.clientID, topic), 1, false, payload)
 	if token.WaitTimeout(time.Second*5) && token.Error() != nil {
 		log.Printf("ERROR: MQTT PUBLISH: %s", token.Error())
 		return token.Error()
 	}
 	return nil
+}
+
+func (netmqtt *NetMqttClient) RegisterTopic(topic string, handler mqtt.MessageHandler) {
+	netmqtt.mqttTopicsMutex.Lock()
+	defer netmqtt.mqttTopicsMutex.Unlock()
+	netmqtt.topics[topic] = handler //adding the topic to the global topic list to be handled in case of disconnection
+	tqtoken := netmqtt.mainMqttClient.Subscribe(topic, 1, handler)
+	tqtoken.WaitTimeout(time.Second * 5)
+}
+
+func (netmqtt *NetMqttClient) DeRegisterTopic(topic string) {
+	netmqtt.mqttTopicsMutex.Lock()
+	defer netmqtt.mqttTopicsMutex.Unlock()
+	netmqtt.mainMqttClient.Unsubscribe(topic)
+	delete(netmqtt.topics, topic) //removing topic from the topic list in case of disconnection
 }

--- a/node-net-manager/mqtt/NetworkManagementHandlers.go
+++ b/node-net-manager/mqtt/NetworkManagementHandlers.go
@@ -17,12 +17,12 @@ type mqttSubnetworkRequest struct {
 	METHOD string `json:"METHOD"`
 }
 type mqttDeployNotification struct {
-	Appname string 	`json:"appname"`
-	Status 	string 	`json:"status"`
-	Instancenumber int `json:"instance_number"`
-	Nsip 	string 	`json:"nsip"`
-	Hostport string	`json:"host_port"`
-	Hostip  string 	`json:"host_ip"`
+	Appname        string `json:"appname"`
+	Status         string `json:"status"`
+	Instancenumber int    `json:"instance_number"`
+	Nsip           string `json:"nsip"`
+	Hostport       string `json:"host_port"`
+	Hostip         string `json:"host_ip"`
 }
 
 func subnetworkAssignmentMqttHandler(client mqtt.Client, msg mqtt.Message) {
@@ -42,7 +42,9 @@ func RequestSubnetworkMqttBlocking() (string, error) {
 
 	request := mqttSubnetworkRequest{METHOD: "GET"}
 	jsonreq, _ := json.Marshal(request)
-	go PublishToBroker("subnet", string(jsonreq))
+	go func() {
+		_ = PublishToBroker("subnet", string(jsonreq))
+	}()
 
 	//waiting for maximum 10 seconds the mqtt handler to receive a response. Otherwise fail the subnetwork request.
 	select {
@@ -57,15 +59,15 @@ func RequestSubnetworkMqttBlocking() (string, error) {
 	return "", net.UnknownNetworkError("Invalid Subnetwork received")
 }
 
-func NotifyDeploymentStatus(appname string, status string, instance int, nsip string, hostip string, hostport string){
+func NotifyDeploymentStatus(appname string, status string, instance int, nsip string, hostip string, hostport string) error {
 	request := mqttDeployNotification{
-		Appname: appname,
-		Status: status,
+		Appname:        appname,
+		Status:         status,
 		Instancenumber: instance,
-		Nsip: nsip,
-		Hostip: hostip,
-		Hostport: hostport,
+		Nsip:           nsip,
+		Hostip:         hostip,
+		Hostport:       hostport,
 	}
 	jsonreq, _ := json.Marshal(request)
-	PublishToBroker("service/deployed", string(jsonreq))
+	return PublishToBroker("service/deployed", string(jsonreq))
 }

--- a/node-net-manager/mqtt/NetworkManagementHandlers.go
+++ b/node-net-manager/mqtt/NetworkManagementHandlers.go
@@ -43,7 +43,7 @@ func RequestSubnetworkMqttBlocking() (string, error) {
 	request := mqttSubnetworkRequest{METHOD: "GET"}
 	jsonreq, _ := json.Marshal(request)
 	go func() {
-		_ = PublishToBroker("subnet", string(jsonreq))
+		_ = GetNetMqttClient().PublishToBroker("subnet", string(jsonreq))
 	}()
 
 	//waiting for maximum 10 seconds the mqtt handler to receive a response. Otherwise fail the subnetwork request.
@@ -69,5 +69,5 @@ func NotifyDeploymentStatus(appname string, status string, instance int, nsip st
 		Hostport:       hostport,
 	}
 	jsonreq, _ := json.Marshal(request)
-	return PublishToBroker("service/deployed", string(jsonreq))
+	return GetNetMqttClient().PublishToBroker("service/deployed", string(jsonreq))
 }

--- a/node-net-manager/mqtt/Tablequery.go
+++ b/node-net-manager/mqtt/Tablequery.go
@@ -58,7 +58,7 @@ type tableQueryRequest struct {
 /*------------------------------------------------------*/
 
 /*
-	returns a singleton pointer to an instance instance of the TableQueryRequestCache class
+returns a singleton pointer to an instance instance of the TableQueryRequestCache class
 */
 func GetTableQueryRequestCacheInstance() *TableQueryRequestCache {
 	once.Do(func() { // <-- atomic, does not allow repeating
@@ -73,9 +73,9 @@ func GetTableQueryRequestCacheInstance() *TableQueryRequestCache {
 }
 
 /*
-	Perform a table query by ServiceIp to the cluster manager
-	The call is blocking and awaits the response for a maximum of 10 seconds
-	set the force value to force the table query even in the event of interest already registered. Used in case of incoming updates notification.
+Perform a table query by ServiceIp to the cluster manager
+The call is blocking and awaits the response for a maximum of 10 seconds
+set the force value to force the table query even in the event of interest already registered. Used in case of incoming updates notification.
 */
 func (cache *TableQueryRequestCache) tableQueryRequestBlocking(sip string, sname string, force_optional ...bool) (TableQueryResponse, error) {
 	reqname := sip + sname
@@ -108,7 +108,7 @@ func (cache *TableQueryRequestCache) tableQueryRequestBlocking(sip string, sname
 		Sname: sname,
 		Sip:   sip,
 	})
-	PublishToBroker("tablequery/request", string(jsonreq))
+	_ = PublishToBroker("tablequery/request", string(jsonreq))
 
 	//waiting for maximum 5 seconds the mqtt handler to receive a response. Otherwise fail the tableQuery.
 	log.Printf("waiting for table query %s", reqname)
@@ -123,23 +123,23 @@ func (cache *TableQueryRequestCache) tableQueryRequestBlocking(sip string, sname
 }
 
 /*
-	Perform a table query by ServiceIp to the cluster manager
-	The call is blocking and awaits the response for a maximum of 5 seconds
+Perform a table query by ServiceIp to the cluster manager
+The call is blocking and awaits the response for a maximum of 5 seconds
 */
 func (cache *TableQueryRequestCache) TableQueryByIpRequestBlocking(sip string, force_optional ...bool) (TableQueryResponse, error) {
 	return cache.tableQueryRequestBlocking(sip, "", force_optional...)
 }
 
 /*
-	Perform a table query by ServiceName to the cluster manager
-	The call is blocking and awaits the response for a maximum of 5 seconds
+Perform a table query by ServiceName to the cluster manager
+The call is blocking and awaits the response for a maximum of 5 seconds
 */
 func (cache *TableQueryRequestCache) TableQueryByJobNameRequestBlocking(jobname string, force_optional ...bool) (TableQueryResponse, error) {
 	return cache.tableQueryRequestBlocking("", jobname, force_optional...)
 }
 
 /*
-	Handler used by the mqtt client to dispatch the table query result
+Handler used by the mqtt client to dispatch the table query result
 */
 func (cache *TableQueryRequestCache) TablequeryResultMqttHandler(client mqtt.Client, msg mqtt.Message) {
 	log.Printf("MQTT - Received mqtt table query message: %s", msg.Payload())

--- a/node-net-manager/mqtt/Tablequery.go
+++ b/node-net-manager/mqtt/Tablequery.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"NetManager/logger"
 	"encoding/json"
 	"errors"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
@@ -167,8 +168,9 @@ func (cache *TableQueryRequestCache) TablequeryResultMqttHandler(client mqtt.Cli
 		channelList := cache.siprequests[key]
 		if channelList != nil {
 			for _, channel := range *channelList {
-				log.Printf("TableQuery response - notifying a channel regarding %s", key)
+				logger.DebugLogger().Printf("TableQuery response - notifying a channel regarding %s", key)
 				channel <- responseStruct
+				close(channel)
 			}
 		}
 		cache.siprequests[key] = nil


### PR DESCRIPTION
Fixes #93 by:

- Making NetMqttHandler a class for easier readability and isolation 
- Avoid acquiring multiple locks in parallel inside the job interest management timer
- Checking event channel before writing events (avoid blocking) 