### PR TITLE
NetManager can regularly update public ip

### DIFF
--- a/cluster-service-manager/service-manager/interfaces/mongodb_requests.py
+++ b/cluster-service-manager/service-manager/interfaces/mongodb_requests.py
@@ -193,6 +193,24 @@ def mongo_update_job_deployed(
     return mongo_jobs.db.jobs.find_one_and_update(
         {"job_name": job_name},
         {"$set": {"status": status, "instance_list": instance_list}},
+        returnNewDocument=False,
+    )
+
+
+def mongo_update_job_address(job_name, node_id, instance_number, host_ip, host_port):
+    global mongo_jobs
+    return mongo_jobs.db.jobs.find_one_and_update(
+        {
+            "job_name": job_name,
+            "instance_list.instance_number": int(instance_number),
+        },
+        {
+            "$set": {
+                "instance_list.$.host_ip": host_ip,
+                "instance_list.$.host_port": int(host_port),
+                "instance_list.$.worker_id": node_id,
+            }
+        },
         return_document=True,
     )
 

--- a/cluster-service-manager/service-manager/interfaces/mqtt_client.py
+++ b/cluster-service-manager/service-manager/interfaces/mqtt_client.py
@@ -26,6 +26,7 @@ def handle_mqtt_message(client, userdata, message):
 
     re_job_deployment_topic = re.search("^nodes/.*/net/service/deployed", topic)
     re_job_undeployment_topic = re.search("^nodes/.*/net/service/undeployed", topic)
+    re_job_address_topic = re.search("^nodes/.*/net/service/address-changed", topic)
     re_job_tablequery_topic = re.search("^nodes/.*/net/tablequery/request", topic)
     re_job_subnet_topic = re.search("^nodes/.*/net/subnet", topic)
     re_job_interest_remove = re.search("^nodes/.*/net/interest/remove", topic)
@@ -40,6 +41,9 @@ def handle_mqtt_message(client, userdata, message):
     if re_job_undeployment_topic is not None:
         logger.debug("JOB-UNDEPLOYMENT-UPDATE")
         _undeployment_handler(client_id, payload)
+    if re_job_address_topic is not None:
+        logger.debug("JOB-ADDRESS-UPDATE")
+        _address_handler(client_id, payload)
     if re_job_tablequery_topic is not None:
         logger.debug("JOB-TABLEQUERY-REQUEST")
         _tablequery_handler(client_id, payload)
@@ -109,6 +113,24 @@ def _deployment_handler(client_id, payload):
 def _undeployment_handler(client_id, payload):
     # TODO
     pass
+
+
+def _address_handler(client_id, payload):
+    appname = payload.get("appname")
+    instance_number = payload.get("instance_number")
+    host_ip = payload.get("host_ip")
+    host_port = payload.get("host_port")
+    try:
+        deployment_address_update(
+            appname,
+            client_id,
+            instance_number,
+            host_ip,
+            host_port,
+        )
+    except Exception as e:
+        traceback.print_exc()
+        print(e)
 
 
 def _interest_remove_handler(client_id, payload):

--- a/cluster-service-manager/service-manager/network/deployment.py
+++ b/cluster-service-manager/service-manager/network/deployment.py
@@ -1,4 +1,4 @@
-from interfaces import mongodb_requests
+from interfaces import mongodb_requests, mqtt_client
 from interfaces.root_service_manager_requests import *
 
 
@@ -13,3 +13,18 @@ def deployment_status_report(
         raise FileNotFoundError
     # Notify System manager
     system_manager_notify_deployment_status(job, node_id)
+
+
+def deployment_address_update(appname, node_id, instance_number, host_ip, host_port):
+    # Update mongo
+    job = mongodb_requests.mongo_update_job_address(
+        appname, node_id, instance_number, host_ip, host_port
+    )
+    if job is None:
+        raise FileNotFoundError
+
+    # Notify System manager
+    system_manager_notify_deployment_status(job, node_id)
+
+    # Notify all interested worker nodes of the address change
+    mqtt_client.mqtt_notify_service_change(appname, type="DEPLOYMENT")

--- a/node-net-manager/TableEntryCache/serviceTranslationTable.go
+++ b/node-net-manager/TableEntryCache/serviceTranslationTable.go
@@ -137,6 +137,18 @@ func (t *TableManager) SearchByNsIP(ip net.IP) (TableEntry, bool) {
 	return TableEntry{}, false
 }
 
+func (t *TableManager) SearchByNodeIp(ip net.IP) []TableEntry {
+	result := make([]TableEntry, 0)
+	t.rwlock.RLock()
+	defer t.rwlock.RUnlock()
+	for _, tableElement := range t.translationTable {
+		if tableElement.Nodeip.Equal(ip) || tableElement.Nodeip.Equal(ip) {
+			result = append(result, tableElement)
+		}
+	}
+	return result
+}
+
 func (t *TableManager) SearchByJobName(jobname string) []TableEntry {
 	t.rwlock.Lock()
 	defer t.rwlock.Unlock()

--- a/node-net-manager/config/netcfg.json
+++ b/node-net-manager/config/netcfg.json
@@ -1,6 +1,6 @@
 {
-  "NodePublicAddress": "0.0.0.0",
-  "NodePublicPort": "50103",
+  "NodeAddress": "0.0.0.0",
+  "NodePort": "50103",
   "ClusterUrl": "0.0.0.0", 
   "ClusterMqttPort": "10003",
   "DefaultInterface": "",

--- a/node-net-manager/config/netcfg.json
+++ b/node-net-manager/config/netcfg.json
@@ -1,6 +1,6 @@
 {
-  "NodeAddress": "0.0.0.0",
-  "NodePort": "50103",
+  "NodePublicAddress": "0.0.0.0",
+  "NodePublicPort": "50103",
   "ClusterUrl": "0.0.0.0", 
   "ClusterMqttPort": "10003",
   "DefaultInterface": "",

--- a/node-net-manager/config/netcfg.json
+++ b/node-net-manager/config/netcfg.json
@@ -5,6 +5,7 @@
   "ClusterMqttPort": "10003",
   "DefaultInterface": "",
   "Debug": false,
+  "PublicIPNetworking": false,
   "MqttCert": "",
   "MqttKey": ""
 }

--- a/node-net-manager/env/EnvironmentManager.go
+++ b/node-net-manager/env/EnvironmentManager.go
@@ -464,7 +464,7 @@ func (env *Environment) CreateHostBridge() error {
 
 // GetTableEntriesOnNode performs a search in the local ServiceCache for entries with the NodeIp of this node
 func (env *Environment) GetTableEntriesOnNode() []TableEntryCache.TableEntry {
-	ip := net.ParseIP(model.NetConfig.NodePublicAddress)
+	ip := net.ParseIP(model.NetConfig.NodeAddress)
 	return env.translationTable.SearchByNodeIp(ip)
 }
 

--- a/node-net-manager/env/EnvironmentManager.go
+++ b/node-net-manager/env/EnvironmentManager.go
@@ -464,7 +464,7 @@ func (env *Environment) CreateHostBridge() error {
 
 // GetTableEntriesOnNode performs a search in the local ServiceCache for entries with the NodeIp of this node
 func (env *Environment) GetTableEntriesOnNode() []TableEntryCache.TableEntry {
-	ip := net.ParseIP(model.NetConfig.NodeAddress)
+	ip := net.ParseIP(model.NetConfig.NodePublicAddress)
 	return env.translationTable.SearchByNodeIp(ip)
 }
 

--- a/node-net-manager/env/EnvironmentManager.go
+++ b/node-net-manager/env/EnvironmentManager.go
@@ -4,6 +4,7 @@ import (
 	"NetManager/TableEntryCache"
 	"NetManager/events"
 	"NetManager/logger"
+	"NetManager/model"
 	"NetManager/mqtt"
 	"NetManager/network"
 	"errors"
@@ -459,6 +460,12 @@ func (env *Environment) CreateHostBridge() error {
 	}
 
 	return nil
+}
+
+// GetTableEntriesOnNode performs a search in the local ServiceCache for entries with the NodeIp of this node
+func (env *Environment) GetTableEntriesOnNode() []TableEntryCache.TableEntry {
+	ip := net.ParseIP(model.NetConfig.NodePublicAddress)
+	return env.translationTable.SearchByNodeIp(ip)
 }
 
 // GetTableEntryByServiceIP Given a ServiceIP this method performs a search in the local ServiceCache

--- a/node-net-manager/handlers/deployment.go
+++ b/node-net-manager/handlers/deployment.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"NetManager/env"
 	"NetManager/logger"
+	"NetManager/model"
 	"NetManager/mqtt"
 	"fmt"
 	"net"
@@ -100,8 +101,8 @@ func deploymentHandler(requestStruct *ContainerDeployTask) (net.IP, net.IP, erro
 		requestStruct.Instancenumber,
 		addr.String(),
 		addrv6.String(),
-		requestStruct.PublicAddr,
-		requestStruct.PublicPort,
+		model.NetConfig.NodePublicAddress,
+		model.NetConfig.NodePublicPort,
 	)
 	if err != nil {
 		logger.ErrorLogger().Println("[ERROR]:", err)

--- a/node-net-manager/model/NetManager.go
+++ b/node-net-manager/model/NetManager.go
@@ -1,14 +1,15 @@
 package model
 
 type NetConfiguration struct {
-	NodePublicAddress string
-	NodePublicPort    string
-	ClusterUrl        string
-	ClusterMqttPort   string
-	DefaultInterface  string
-	Debug             bool
-	MqttCert          string
-	MqttKey           string
+	NodePublicAddress  string
+	NodePublicPort     string
+	ClusterUrl         string
+	ClusterMqttPort    string
+	DefaultInterface   string
+	Debug              bool
+	PublicIPNetworking bool
+	MqttCert           string
+	MqttKey            string
 }
 
 var NetConfig NetConfiguration

--- a/node-net-manager/model/NetManager.go
+++ b/node-net-manager/model/NetManager.go
@@ -1,8 +1,8 @@
 package model
 
 type NetConfiguration struct {
-	NodeAddress        string
-	NodePort           string
+	NodePublicAddress  string
+	NodePublicPort     string
 	ClusterUrl         string
 	ClusterMqttPort    string
 	DefaultInterface   string

--- a/node-net-manager/model/NetManager.go
+++ b/node-net-manager/model/NetManager.go
@@ -1,8 +1,8 @@
 package model
 
 type NetConfiguration struct {
-	NodePublicAddress  string
-	NodePublicPort     string
+	NodeAddress        string
+	NodePort           string
 	ClusterUrl         string
 	ClusterMqttPort    string
 	DefaultInterface   string

--- a/node-net-manager/mqtt/NetworkManagementHandlers.go
+++ b/node-net-manager/mqtt/NetworkManagementHandlers.go
@@ -75,3 +75,15 @@ func NotifyDeploymentStatus(appname string, status string, instance int, nsip st
 	jsonreq, _ := json.Marshal(request)
 	return GetNetMqttClient().PublishToBroker("service/deployed", string(jsonreq))
 }
+
+// Update cluster about new node adress
+func NotifyAddressChange(appname string, instance int, hostip string, hostport string) error {
+	request := mqttDeployNotification{
+		Appname:        appname,
+		Instancenumber: instance,
+		Hostip:         hostip,
+		Hostport:       hostport,
+	}
+	jsonreq, _ := json.Marshal(request)
+	return GetNetMqttClient().PublishToBroker("service/address-changed", string(jsonreq))
+}

--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -141,6 +141,7 @@ func GetOutboundIP() net.IP {
 		logger.InfoLogger().Println("Using public IP address: ", addr.String())
 	} else {
 		addr = conn.LocalAddr().(*net.UDPAddr)
+		logger.InfoLogger().Println("Using public IP address: ", addr.String())
 	}
 
 	return addr.IP

--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -6,9 +6,11 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"math/big"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -134,15 +136,29 @@ func GetOutboundIP() net.IP {
 	}
 	defer conn.Close()
 
-	// get public or private outbound ip
-	var addr *net.UDPAddr
 	if model.NetConfig.PublicIPNetworking {
-		addr = conn.RemoteAddr().(*net.UDPAddr)
-		logger.InfoLogger().Println("Using public IP address: ", addr.String())
-	} else {
-		addr = conn.LocalAddr().(*net.UDPAddr)
-		logger.InfoLogger().Println("Using public IP address: ", addr.String())
-	}
+		// get public ip (nat ip)
+		req, err := http.Get("https://ifconfig.co")
+		if err != nil {
+			logger.ErrorLogger().Printf("%v", err.Error())
+		}
+		defer func(Body io.ReadCloser) {
+			err := Body.Close()
+			if err != nil {
+				logger.ErrorLogger().Printf("%v", err.Error())
+			}
+		}(req.Body)
 
+		body, err := io.ReadAll(req.Body)
+		if err == nil {
+			logger.InfoLogger().Println("Using public IP address: ", body)
+			return net.ParseIP(string(body))
+		}
+		logger.ErrorLogger().Printf("%v", err.Error())
+	}
+	
+	// get local outbound ip
+	addr := conn.LocalAddr().(*net.UDPAddr)
+	logger.InfoLogger().Println("Using private IP address: ", addr.String())
 	return addr.IP
 }

--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"NetManager/logger"
 	"NetManager/model"
 	"crypto/sha1"
 	"encoding/base64"
@@ -133,7 +134,14 @@ func GetOutboundIP() net.IP {
 	}
 	defer conn.Close()
 
-	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	// get public or private outbound ip
+	var addr *net.UDPAddr
+	if model.NetConfig.PublicIPNetworking {
+		addr = conn.RemoteAddr().(*net.UDPAddr)
+		logger.InfoLogger().Println("Using public IP address: ", addr.String())
+	} else {
+		addr = conn.LocalAddr().(*net.UDPAddr)
+	}
 
-	return localAddr.IP
+	return addr.IP
 }

--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -151,12 +151,12 @@ func GetOutboundIP() net.IP {
 
 		body, err := io.ReadAll(req.Body)
 		if err == nil {
-			logger.InfoLogger().Println("Using public IP address: ", body)
-			return net.ParseIP(string(body))
+			logger.InfoLogger().Println("Using public IP address: ", string(body))
+			return net.ParseIP(string(body[:len(body)-1]))
 		}
 		logger.ErrorLogger().Printf("%v", err.Error())
 	}
-	
+
 	// get local outbound ip
 	addr := conn.LocalAddr().(*net.UDPAddr)
 	logger.InfoLogger().Println("Using private IP address: ", addr.String())

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -15,9 +15,12 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gorilla/mux"
 )
+
+const IP_UPDATE_TIMER = 2 * time.Minute
 
 type undeployRequest struct {
 	Servicename    string `json:"serviceName"`
@@ -34,14 +37,38 @@ type DeployResponse struct {
 	NsAddress   string `json:"nsAddress"`
 }
 
+func update() {
+	for {
+		select {
+		case <-time.After(IP_UPDATE_TIMER):
+			func() {
+				defaultLink := network.GetOutboundIP()
+				if model.NetConfig.NodePublicAddress != defaultLink.String() {
+					logger.InfoLogger().Printf("Updating NodePublicAddress from %s to %s", model.NetConfig.NodePublicAddress, defaultLink.String())
+					defer func() { model.NetConfig.NodePublicAddress = defaultLink.String() }()
+					// update service in the cluster
+					//for each service instance in the worker, update the public address
+					for _, si := range Env.GetTableEntriesOnNode() {
+						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePublicPort)
+						if err != nil {
+							logger.ErrorLogger().Println("[ERROR]:", err)
+						}
+					}
+				}
+			}()
+		}
+	}
+}
+
 func HandleRequests(port int) {
 	netRouter := mux.NewRouter().StrictSlash(true)
 	netRouter.HandleFunc("/register", register).Methods("POST")
 
-	//If default route, fetch default gateway address and use that.
+	//If default route, fetch default gateway address and use that, update regularly
 	if model.NetConfig.NodePublicAddress == "0.0.0.0" {
 		defaultLink := network.GetOutboundIP()
 		model.NetConfig.NodePublicAddress = defaultLink.String()
+		go update()
 	}
 
 	handlers.RegisterAllManagers(&Env, &model.WorkerID, model.NetConfig.NodePublicAddress, model.NetConfig.NodePublicPort, netRouter)

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -43,13 +43,13 @@ func update() {
 		case <-time.After(IP_UPDATE_TIMER):
 			func() {
 				defaultLink := network.GetOutboundIP()
-				if model.NetConfig.NodePublicAddress != defaultLink.String() {
-					logger.InfoLogger().Printf("Updating NodePublicAddress from %s to %s", model.NetConfig.NodePublicAddress, defaultLink.String())
-					defer func() { model.NetConfig.NodePublicAddress = defaultLink.String() }()
+				if model.NetConfig.NodeAddress != defaultLink.String() {
+					logger.InfoLogger().Printf("Updating NodeAddress from %s to %s", model.NetConfig.NodeAddress, defaultLink.String())
+					defer func() { model.NetConfig.NodeAddress = defaultLink.String() }()
 					// update service in the cluster
 					//for each service instance in the worker, update the public address
 					for _, si := range Env.GetTableEntriesOnNode() {
-						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePublicPort)
+						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePort)
 						if err != nil {
 							logger.ErrorLogger().Println("[ERROR]:", err)
 						}
@@ -65,13 +65,13 @@ func HandleRequests(port int) {
 	netRouter.HandleFunc("/register", register).Methods("POST")
 
 	//If default route, fetch default gateway address and use that, update regularly
-	if model.NetConfig.NodePublicAddress == "0.0.0.0" {
+	if model.NetConfig.NodeAddress == "0.0.0.0" {
 		defaultLink := network.GetOutboundIP()
-		model.NetConfig.NodePublicAddress = defaultLink.String()
+		model.NetConfig.NodeAddress = defaultLink.String()
 		go update()
 	}
 
-	handlers.RegisterAllManagers(&Env, &model.WorkerID, model.NetConfig.NodePublicAddress, model.NetConfig.NodePublicPort, netRouter)
+	handlers.RegisterAllManagers(&Env, &model.WorkerID, model.NetConfig.NodeAddress, model.NetConfig.NodePort, netRouter)
 
 	if port <= 0 {
 		logger.InfoLogger().Println("Starting NetManager on unix socket /etc/netmanager/netmanager.sock")
@@ -136,8 +136,8 @@ func register(writer http.ResponseWriter, request *http.Request) {
 	//log registration startup
 	logger.InfoLogger().Printf(
 		"STARTUP_CONFIG: Node=%s:%s | Cluster=%s:%s",
-		model.NetConfig.NodePublicAddress,
-		model.NetConfig.NodePublicPort,
+		model.NetConfig.NodeAddress,
+		model.NetConfig.NodePort,
 		model.NetConfig.ClusterUrl,
 		model.NetConfig.ClusterMqttPort,
 	)

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -43,13 +43,13 @@ func update() {
 		case <-time.After(IP_UPDATE_TIMER):
 			func() {
 				defaultLink := network.GetOutboundIP()
-				if model.NetConfig.NodeAddress != defaultLink.String() {
-					logger.InfoLogger().Printf("Updating NodeAddress from %s to %s", model.NetConfig.NodeAddress, defaultLink.String())
-					defer func() { model.NetConfig.NodeAddress = defaultLink.String() }()
+				if model.NetConfig.NodePublicAddress != defaultLink.String() {
+					logger.InfoLogger().Printf("Updating NodePublicAddress from %s to %s", model.NetConfig.NodePublicAddress, defaultLink.String())
+					defer func() { model.NetConfig.NodePublicAddress = defaultLink.String() }()
 					// update service in the cluster
 					//for each service instance in the worker, update the public address
 					for _, si := range Env.GetTableEntriesOnNode() {
-						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePort)
+						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePublicPort)
 						if err != nil {
 							logger.ErrorLogger().Println("[ERROR]:", err)
 						}
@@ -65,13 +65,13 @@ func HandleRequests(port int) {
 	netRouter.HandleFunc("/register", register).Methods("POST")
 
 	//If default route, fetch default gateway address and use that, update regularly
-	if model.NetConfig.NodeAddress == "0.0.0.0" {
+	if model.NetConfig.NodePublicAddress == "0.0.0.0" {
 		defaultLink := network.GetOutboundIP()
-		model.NetConfig.NodeAddress = defaultLink.String()
+		model.NetConfig.NodePublicAddress = defaultLink.String()
 		go update()
 	}
 
-	handlers.RegisterAllManagers(&Env, &model.WorkerID, model.NetConfig.NodeAddress, model.NetConfig.NodePort, netRouter)
+	handlers.RegisterAllManagers(&Env, &model.WorkerID, model.NetConfig.NodePublicAddress, model.NetConfig.NodePublicPort, netRouter)
 
 	if port <= 0 {
 		logger.InfoLogger().Println("Starting NetManager on unix socket /etc/netmanager/netmanager.sock")
@@ -136,8 +136,8 @@ func register(writer http.ResponseWriter, request *http.Request) {
 	//log registration startup
 	logger.InfoLogger().Printf(
 		"STARTUP_CONFIG: Node=%s:%s | Cluster=%s:%s",
-		model.NetConfig.NodeAddress,
-		model.NetConfig.NodePort,
+		model.NetConfig.NodePublicAddress,
+		model.NetConfig.NodePublicPort,
 		model.NetConfig.ClusterUrl,
 		model.NetConfig.ClusterMqttPort,
 	)

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -39,23 +39,19 @@ type DeployResponse struct {
 
 func update() {
 	for {
-		select {
-		case <-time.After(IP_UPDATE_TIMER):
-			func() {
-				defaultLink := network.GetOutboundIP()
-				if model.NetConfig.NodePublicAddress != defaultLink.String() {
-					logger.InfoLogger().Printf("Updating NodePublicAddress from %s to %s", model.NetConfig.NodePublicAddress, defaultLink.String())
-					defer func() { model.NetConfig.NodePublicAddress = defaultLink.String() }()
-					// update service in the cluster
-					//for each service instance in the worker, update the public address
-					for _, si := range Env.GetTableEntriesOnNode() {
-						err := mqtt.NotifyDeploymentStatus(si.Appname, "DEPLOYED", si.Instancenumber, si.Nsip.String(), si.Nsipv6.String(), defaultLink.String(), model.NetConfig.NodePublicPort)
-						if err != nil {
-							logger.ErrorLogger().Println("[ERROR]:", err)
-						}
-					}
+		time.Sleep(IP_UPDATE_TIMER)
+		defaultLink := network.GetOutboundIP()
+		if model.NetConfig.NodePublicAddress != defaultLink.String() {
+			logger.InfoLogger().Printf("Updating NodePublicAddress from %s to %s", model.NetConfig.NodePublicAddress, defaultLink.String())
+			// update service in the cluster
+			//for each service instance in the worker, update the public address
+			for _, si := range Env.GetTableEntriesOnNode() {
+				err := mqtt.NotifyAddressChange(si.Appname, si.Instancenumber, defaultLink.String(), model.NetConfig.NodePublicPort)
+				if err != nil {
+					logger.ErrorLogger().Println("[ERROR]:", err)
 				}
-			}()
+			}
+			model.NetConfig.NodePublicAddress = defaultLink.String()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #212 
Introduces a new config parameter called `PublicIPNetworking` which is set to `false` per default. When enabled the NetManager will look up it's remote/public IP and use that as the node address.
The update frequency is currently set to two minutes.
If the IP changes the NetManager performs a search on the locally cached service instances and looks for all service instances whose NodeIp matches the previous node address.
For these service instances the NetManager will resend a deployment notification containing the new host ip.

When the `NodePublicAdress` is not set to `0.0.0.0` the NetManager operates as it did previously