### PR TITLE
Contextualise Fatal Logs

### DIFF
--- a/node-net-manager/cmd/root.go
+++ b/node-net-manager/cmd/root.go
@@ -41,7 +41,7 @@ func startNetManager() error {
 
 	err := gonfig.GetConf(cfgFile, &model.NetConfig)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to load config file: %s", err)
 	}
 
 	if model.NetConfig.Debug {

--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -125,11 +125,11 @@ func defaultRoute() (*netlink.Link, error) {
 	return &defNetlink, nil
 }
 
-// Get preferred outbound ip of this machine
+// GetOutboundIP finds the preferred outbound ip of this machine
 func GetOutboundIP() net.IP {
 	conn, err := net.Dial("udp", "8.8.8.8:80")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to dial DNS: %s", err)
 	}
 	defer conn.Close()
 

--- a/node-net-manager/proxy/ProxySetup.go
+++ b/node-net-manager/proxy/ProxySetup.go
@@ -118,7 +118,7 @@ func (proxy *GoProxyTunnel) createTun() {
 	config.Name = proxy.HostTUNDeviceName
 	ifce, err := water.New(config)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Unable to create new TUN/TAP interface: %s", err)
 	}
 
 	logger.InfoLogger().Println("Bringing tun up with addr " + proxy.tunNetIP + "/12")

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -51,7 +51,7 @@ func HandleRequests(port int) {
 		_ = os.Remove("/etc/netmanager/netmanager.sock")
 		listener, err := net.Listen("unix", "/etc/netmanager/netmanager.sock")
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("Could not create listner: %s", err)
 		}
 		log.Fatal(http.Serve(listener, netRouter))
 	} else {


### PR DESCRIPTION
I spent quite a bit of time hunting down a cryptic error message as I was unable to immediately locate which component had produced the error.
To make this more clear in the future I've added a bit of context to any fatal logs where there are no other logs in the immediate vicinity.