### PR TITLE
Added function to retrieve the next available service IP

### DIFF
--- a/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
+++ b/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
@@ -49,9 +49,9 @@ class AvailableServiceIPsSchema(Schema):
     available_service_ips = fields.Nested(ServiceIpSchema, allow_none=True)
 
 @netinfoblp.route("/available-ip/<x>", methods=["GET"])
+@netinfoblp.route("/available-ip/", methods=["GET"])
 @netinfoblp.arguments(IPQueryArgsSchema, location="query")
 @netinfoblp.response(200, AvailableServiceIPsSchema, content_type="application/json")
-@jwt_auth_required()
 def get_available_service_ip(query_args,x=1):
     """
     Get the next x available service IP addresses without reserving them. If x is not asigned, returns a single available IP. 
@@ -65,7 +65,7 @@ def get_available_service_ip(query_args,x=1):
     else:
         version = None
 
-    return netinfo_management.get_next_x_available_service_ips(x,version=version)
+    return netinfo_management.get_next_x_available_service_ips(int(x),version=version)
 
 @netinfoblp.route("/<service_name>", methods=["GET"])
 @netinfoblp.response(200, ServiceNetinfoSchema, content_type="application/json")

--- a/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
+++ b/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
@@ -3,6 +3,7 @@ from marshmallow import fields, Schema
 
 from operations import netinfo_management
 from utils.security_utils import jwt_auth_required
+from network.subnetwork_management import get_next_available_ip
 
 # ........ Service networking information endpoints ............. #
 
@@ -38,6 +39,21 @@ class ServiceNetinfoSchema(Schema):
     service_ip_list = fields.Nested(ServiceIpSchema, many=True)
     instance_list = fields.Nested(InstanceSchema, many=True)
 
+
+
+class AvailableServiceIPSchema(Schema):
+    service_ip = fields.String(allow_none=True)
+
+@netinfoblp.route("/available-ip", methods=["GET"])
+@netinfoblp.response(200, AvailableServiceIPSchema, content_type="application/json")
+@jwt_auth_required()
+def get_available_service_ip():
+    """
+    Get the next available service IP address from the 10.30.x.y range without reserving it
+    """
+    ip = get_next_available_ip()
+
+    return {"service_ip": ip}
 
 @netinfoblp.route("/<service_name>", methods=["GET"])
 @netinfoblp.response(200, ServiceNetinfoSchema, content_type="application/json")

--- a/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
+++ b/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
@@ -40,19 +40,18 @@ class ServiceNetinfoSchema(Schema):
 
 class IPQueryArgsSchema(Schema):
     v = fields.String(
-        required=False, 
-        load_default=None, 
-        validate=lambda x: x in ("4", "6")
+        required=False
     )
 
 class AvailableServiceIPsSchema(Schema):
-    available_service_ips = fields.Nested(ServiceIpSchema, allow_none=True)
+    available_service_ips = fields.Nested(ServiceIpSchema, many=True)
 
 @netinfoblp.route("/available-ip/<x>", methods=["GET"])
 @netinfoblp.route("/available-ip/", methods=["GET"])
 @netinfoblp.arguments(IPQueryArgsSchema, location="query")
 @netinfoblp.response(200, AvailableServiceIPsSchema, content_type="application/json")
-def get_available_service_ip(query_args,x=1):
+@jwt_auth_required()
+def get_available_service_ip(query_args, x=1):
     """
     Get the next x available service IP addresses without reserving them. If x is not asigned, returns a single available IP. 
     Its IP version can be specified via query parameter "v" -> "4" for IPv4, "6" for IPv6, or omit for both.

--- a/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
+++ b/root-service-manager/service-manager/blueprints/netinfo_blueprints.py
@@ -3,7 +3,6 @@ from marshmallow import fields, Schema
 
 from operations import netinfo_management
 from utils.security_utils import jwt_auth_required
-from network.subnetwork_management import get_next_available_ip
 
 # ........ Service networking information endpoints ............. #
 
@@ -39,21 +38,34 @@ class ServiceNetinfoSchema(Schema):
     service_ip_list = fields.Nested(ServiceIpSchema, many=True)
     instance_list = fields.Nested(InstanceSchema, many=True)
 
+class IPQueryArgsSchema(Schema):
+    v = fields.String(
+        required=False, 
+        load_default=None, 
+        validate=lambda x: x in ("4", "6")
+    )
 
+class AvailableServiceIPsSchema(Schema):
+    available_service_ips = fields.Nested(ServiceIpSchema, allow_none=True)
 
-class AvailableServiceIPSchema(Schema):
-    service_ip = fields.String(allow_none=True)
-
-@netinfoblp.route("/available-ip", methods=["GET"])
-@netinfoblp.response(200, AvailableServiceIPSchema, content_type="application/json")
+@netinfoblp.route("/available-ip/<x>", methods=["GET"])
+@netinfoblp.arguments(IPQueryArgsSchema, location="query")
+@netinfoblp.response(200, AvailableServiceIPsSchema, content_type="application/json")
 @jwt_auth_required()
-def get_available_service_ip():
+def get_available_service_ip(query_args,x=1):
     """
-    Get the next available service IP address from the 10.30.x.y range without reserving it
+    Get the next x available service IP addresses without reserving them. If x is not asigned, returns a single available IP. 
+    Its IP version can be specified via query parameter "v" -> "4" for IPv4, "6" for IPv6, or omit for both.
     """
-    ip = get_next_available_ip()
+    version_param = query_args.get("v")
+    if version_param == "4":
+        version = "v4"
+    elif version_param == "6":
+        version = "v6"
+    else:
+        version = None
 
-    return {"service_ip": ip}
+    return netinfo_management.get_next_x_available_service_ips(x,version=version)
 
 @netinfoblp.route("/<service_name>", methods=["GET"])
 @netinfoblp.response(200, ServiceNetinfoSchema, content_type="application/json")

--- a/root-service-manager/service-manager/interfaces/mongodb_requests.py
+++ b/root-service-manager/service-manager/interfaces/mongodb_requests.py
@@ -197,6 +197,23 @@ def mongo_get_service_address_from_cache():
         return entry["ipv4"]
     else:
         return None
+    
+def mongo_get_service_address_from_cache_not_deleting(x=1):
+    """
+    Returns the next 'x' available Service addresses from the free addresses cache 
+    without removing them.
+    @param x: int, max number of addresses to fetch
+    @return: list of int[4] in the shape [10,30,x,y]
+    """
+    global mongo_net
+    netdb = mongo_net.db.netcache
+
+    entries = netdb.find({'type': 'free_service_ip'}).limit(x)
+
+    if entries is not None:
+        return [entry["ipv4"] for entry in entries]
+    else:
+        return []
 
 
 def mongo_free_service_address_to_cache(address):
@@ -281,6 +298,23 @@ def mongo_get_service_address_from_cache_v6():
     else:
         return None
     
+def mongo_get_service_address_from_cache_not_deleting_v6(x=1):
+    """
+    Returns the next 'x' available Service addresses from the free addresses cache 
+    without removing them.
+    @param x: int, max number of addresses to fetch
+    @return: list of int[16] in the shape [253, 255, [0, 8], a, b, c, d, e, f, g, h, i, j, k, l, m]
+             equal to [fdff:[00, 08]00::]
+    """
+    global mongo_net
+    netdb = mongo_net.db.netcache
+
+    entries = netdb.find({'type': 'free_service_ipv6'}).limit(x)
+
+    if entries is not None:
+        return [entry["ipv6"] for entry in entries]
+    else:
+        return []
 
 def mongo_free_service_address_to_cache_v6(address):
     """

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -49,7 +49,7 @@ def get_next_available_ip(x=1):
     # if theres no more in cache, get them from mongo
     if len(ips) < x:
         addr = mongodb_requests.mongo_get_next_service_ip()
-        
+
         while len(ips) < x:
             
             if addr is None:

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -212,45 +212,7 @@ def new_rr_ip_v6():
         return _addr_stringify(addr)
     
 
-   
-def get_next_available_ip_v6(x=1):
-    """
-    Function used to get the next x available service IPv6 addresses without reserving them.
-    Prioritizes cached free addresses before scanning for new ones.
-    This function is read-only and does not modify the pool of available addresses.
-    @param x: int, number of IPs to fetch
-    @return: list of string,
-        The next available IPv6 addresses from the pool, or an empty list if none are available.
-    """
-    ips = []
 
-    while len(ips) < x:
-        addr = mongodb_requests.mongo_get_service_address_from_cache_v6()
-        if addr is None:
-            break
-        ips.append(_addr_stringify(addr))
-
-    if len(ips) < x:
-        addr = mongodb_requests.mongo_get_next_service_ip_v6()
-
-        while len(ips) < x:
-            if addr is None:
-                break
-
-            job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(addr))
-            while job is not None:
-                next_addr = _increase_service_address_v6(addr)
-                job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(next_addr))
-                addr = next_addr
-
-            if addr is None:
-                break
-
-            ips.append(_addr_stringify(addr))
-
-            addr = _increase_service_address_v6(addr)
-
-    return ips
 
 
 def get_next_available_ip_v6(x=1):

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -34,6 +34,35 @@ def new_job_rr_address(job_data):
     return new_instance_ip()
 
 
+
+def get_next_available_ip():
+    """
+    Function used to get the next available service IP address without reserving it.
+    This function is read-only and does not modify the pool of available addresses.
+    @return: string,
+        The next available IP address from the pool, or None if no addresses are available. It does not remove the IP from the pool. 
+    """
+    addr = mongodb_requests.mongo_get_service_address_from_cache()
+    
+    if addr is None:
+        addr = mongodb_requests.mongo_get_next_service_ip()
+        job = mongodb_requests.mongo_find_job_by_ip(addr)
+        if job is not None:
+            next_addr = _increase_service_address(addr)
+            while job is not None:
+                job = mongodb_requests.mongo_find_job_by_ip(next_addr)
+                if job is not None:
+                    next_addr = _increase_service_address(next_addr)
+            addr = next_addr
+    
+    if addr[2] == 253 and addr[3] == 253: 
+        return None
+
+    return _addr_stringify(addr)
+
+
+
+
 def new_instance_ip():
     """
     Function used to assign a new instance IP address for a Service that is going to be deployed.

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -34,6 +34,7 @@ def new_job_rr_address(job_data):
     return new_instance_ip()
 
 
+
 def get_next_available_ip(x=1):
     """
     Function used to get the next x available service IPv4 addresses without reserving them.
@@ -42,36 +43,38 @@ def get_next_available_ip(x=1):
     @return: list of string,
         The next available IP addresses from the pool, or an empty list if none are available.
     """
-    ips = []
+    ips_from_cache = mongodb_requests.mongo_get_service_address_from_cache_not_deleting(x)
+    ips = [_addr_stringify(addr) for addr in ips_from_cache]
 
-    while len(ips) < x:
-        addr = mongodb_requests.mongo_get_service_address_from_cache()
-        if addr is None:
-            break  
-        ips.append(_addr_stringify(addr))
-
+    # if theres no more in cache, get them from mongo
     if len(ips) < x:
         addr = mongodb_requests.mongo_get_next_service_ip()
-
+        
         while len(ips) < x:
-            if addr is None:
-                break
-            job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(addr))
-            while job is not None:
-                next_addr = _increase_service_address(addr)
-                job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(next_addr))
-                addr = next_addr
-
+            
             if addr is None or (addr[2] == 253 and addr[3] == 253):
                 break
-
-            ips.append(_addr_stringify(addr))
-
-            addr = _increase_service_address(addr)
+            
+            while True:
+                ip_str = _addr_stringify(addr)
+                
+                job = mongodb_requests.mongo_find_job_by_ip(ip_str)
+                
+                if job is None:
+                    ips.append(ip_str)
+                    break 
+                else:
+                    try:
+                        addr = _increase_service_address(addr)
+                    except RuntimeError:
+                        return ips 
+            
+            try:
+                addr = _increase_service_address(addr)
+            except RuntimeError:
+                break 
 
     return ips
-
-
 
 
 
@@ -250,7 +253,47 @@ def get_next_available_ip_v6(x=1):
     return ips
 
 
+def get_next_available_ip_v6(x=1):
+    """
+    Function used to get the next x available service IPv6 addresses without reserving them.
+    Prioritizes cached free addresses before scanning for new ones.
+    This function is read-only and does not modify the pool of available addresses.
+    @param x: int, number of IPs to fetch
+    @return: list of string,
+        The next available IPv6 addresses from the pool, or an empty list if none are available.
+    """
 
+    ips_from_cache = mongodb_requests.mongo_get_service_address_from_cache_not_deleting_v6(x)
+    ips = [_addr_stringify(addr) for addr in ips_from_cache]
+
+    if len(ips) < x:
+        addr = mongodb_requests.mongo_get_next_service_ip_v6()
+
+        while len(ips) < x:
+            
+            if addr is None:
+                break
+            
+            while True:
+                ip_str = _addr_stringify(addr)
+                
+                job = mongodb_requests.mongo_find_job_by_ip(ip_str)
+                
+                if job is None:
+                    ips.append(ip_str)
+                    break 
+                else:
+                    try:
+                        addr = _increase_service_address_v6(addr)
+                    except RuntimeError:
+                        return ips 
+            
+            try:
+                addr = _increase_service_address_v6(addr)
+            except RuntimeError:
+                break 
+
+    return ips
 
 
 def new_instance_ip_v6():

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -34,31 +34,44 @@ def new_job_rr_address(job_data):
     return new_instance_ip()
 
 
-
-def get_next_available_ip():
+def get_next_available_ip(x=1):
     """
-    Function used to get the next available service IP address without reserving it.
+    Function used to get the next x available service IPv4 addresses without reserving them.
     This function is read-only and does not modify the pool of available addresses.
-    @return: string,
-        The next available IP address from the pool, or None if no addresses are available. It does not remove the IP from the pool. 
+    @param x: int, number of IPs to fetch
+    @return: list of string,
+        The next available IP addresses from the pool, or an empty list if none are available.
     """
-    addr = mongodb_requests.mongo_get_service_address_from_cache()
-    
-    if addr is None:
-        addr = mongodb_requests.mongo_get_next_service_ip()
-        job = mongodb_requests.mongo_find_job_by_ip(addr)
-        if job is not None:
-            next_addr = _increase_service_address(addr)
-            while job is not None:
-                job = mongodb_requests.mongo_find_job_by_ip(next_addr)
-                if job is not None:
-                    next_addr = _increase_service_address(next_addr)
-            addr = next_addr
-    
-    if addr[2] == 253 and addr[3] == 253: 
-        return None
+    ips = []
 
-    return _addr_stringify(addr)
+    while len(ips) < x:
+        addr = mongodb_requests.mongo_get_service_address_from_cache()
+        if addr is None:
+            break  
+        ips.append(_addr_stringify(addr))
+
+    if len(ips) < x:
+        addr = mongodb_requests.mongo_get_next_service_ip()
+
+        while len(ips) < x:
+            if addr is None:
+                break
+            job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(addr))
+            while job is not None:
+                next_addr = _increase_service_address(addr)
+                job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(next_addr))
+                addr = next_addr
+
+            if addr is None or (addr[2] == 253 and addr[3] == 253):
+                break
+
+            ips.append(_addr_stringify(addr))
+
+            addr = _increase_service_address(addr)
+
+    return ips
+
+
 
 
 
@@ -194,6 +207,51 @@ def new_rr_ip_v6():
                 addr = None
 
         return _addr_stringify(addr)
+    
+
+   
+def get_next_available_ip_v6(x=1):
+    """
+    Function used to get the next x available service IPv6 addresses without reserving them.
+    Prioritizes cached free addresses before scanning for new ones.
+    This function is read-only and does not modify the pool of available addresses.
+    @param x: int, number of IPs to fetch
+    @return: list of string,
+        The next available IPv6 addresses from the pool, or an empty list if none are available.
+    """
+    ips = []
+
+    while len(ips) < x:
+        addr = mongodb_requests.mongo_get_service_address_from_cache_v6()
+        if addr is None:
+            break
+        ips.append(_addr_stringify(addr))
+
+    if len(ips) < x:
+        addr = mongodb_requests.mongo_get_next_service_ip_v6()
+
+        while len(ips) < x:
+            if addr is None:
+                break
+
+            job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(addr))
+            while job is not None:
+                next_addr = _increase_service_address_v6(addr)
+                job = mongodb_requests.mongo_find_job_by_ip(_addr_stringify(next_addr))
+                addr = next_addr
+
+            if addr is None:
+                break
+
+            ips.append(_addr_stringify(addr))
+
+            addr = _increase_service_address_v6(addr)
+
+    return ips
+
+
+
+
 
 def new_instance_ip_v6():
     """
@@ -413,3 +471,4 @@ def _addr_destringify_v6(addrstr):
         addr.append(int(num[0:2], 16))
         addr.append(int(num[2:4], 16))
     return addr
+

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -52,7 +52,7 @@ def get_next_available_ip(x=1):
         
         while len(ips) < x:
             
-            if addr is None or (addr[2] == 253 and addr[3] == 253):
+            if addr is None:
                 break
             
             while True:

--- a/root-service-manager/service-manager/network/subnetwork_management.py
+++ b/root-service-manager/service-manager/network/subnetwork_management.py
@@ -45,34 +45,20 @@ def get_next_available_ip(x=1):
     """
     ips_from_cache = mongodb_requests.mongo_get_service_address_from_cache_not_deleting(x)
     ips = [_addr_stringify(addr) for addr in ips_from_cache]
-
     # if theres no more in cache, get them from mongo
     if len(ips) < x:
         addr = mongodb_requests.mongo_get_next_service_ip()
 
-        while len(ips) < x:
-            
-            if addr is None:
-                break
-            
-            while True:
-                ip_str = _addr_stringify(addr)
-                
-                job = mongodb_requests.mongo_find_job_by_ip(ip_str)
-                
-                if job is None:
-                    ips.append(ip_str)
-                    break 
-                else:
-                    try:
-                        addr = _increase_service_address(addr)
-                    except RuntimeError:
-                        return ips 
-            
+        while len(ips) < x and addr is not None:
+            ip_str = _addr_stringify(addr)
+            job = mongodb_requests.mongo_find_job_by_ip(ip_str)
+            if job is None:
+                ips.append(ip_str)
+
             try:
                 addr = _increase_service_address(addr)
             except RuntimeError:
-                break 
+                break
 
     return ips
 
@@ -224,38 +210,26 @@ def get_next_available_ip_v6(x=1):
     @return: list of string,
         The next available IPv6 addresses from the pool, or an empty list if none are available.
     """
-
     ips_from_cache = mongodb_requests.mongo_get_service_address_from_cache_not_deleting_v6(x)
     ips = [_addr_stringify(addr) for addr in ips_from_cache]
 
     if len(ips) < x:
         addr = mongodb_requests.mongo_get_next_service_ip_v6()
 
-        while len(ips) < x:
-            
-            if addr is None:
-                break
-            
-            while True:
-                ip_str = _addr_stringify(addr)
-                
-                job = mongodb_requests.mongo_find_job_by_ip(ip_str)
-                
-                if job is None:
-                    ips.append(ip_str)
-                    break 
-                else:
-                    try:
-                        addr = _increase_service_address_v6(addr)
-                    except RuntimeError:
-                        return ips 
-            
+        while len(ips) < x and addr is not None:
+            ip_str = _addr_stringify(addr)
+            job = mongodb_requests.mongo_find_job_by_ip(ip_str)
+
+            if job is None:
+                ips.append(ip_str)
+
             try:
                 addr = _increase_service_address_v6(addr)
             except RuntimeError:
-                break 
+                break
 
     return ips
+
 
 
 def new_instance_ip_v6():

--- a/root-service-manager/service-manager/operations/netinfo_management.py
+++ b/root-service-manager/service-manager/operations/netinfo_management.py
@@ -86,6 +86,7 @@ def get_next_x_available_service_ips(x=1, version=None):
     ipv4_list = []
     ipv6_list = []
 
+
     if version is None:
         ipv4_list = get_next_available_ip(x)
         ipv6_list = get_next_available_ip_v6(x)
@@ -93,6 +94,7 @@ def get_next_x_available_service_ips(x=1, version=None):
         ipv4_list = get_next_available_ip(x)
     elif version == "v6":
         ipv6_list = get_next_available_ip_v6(x)
+    
 
 
     for ip in ipv4_list:
@@ -100,5 +102,6 @@ def get_next_x_available_service_ips(x=1, version=None):
         
     for ip in ipv6_list:
         ips["available_service_ips"].append(_format_service_ip(addr_v6=ip))
+
 
     return ips

--- a/root-service-manager/service-manager/operations/netinfo_management.py
+++ b/root-service-manager/service-manager/operations/netinfo_management.py
@@ -1,5 +1,5 @@
 from network import tablequery
-
+from network.subnetwork_management import get_next_available_ip,get_next_available_ip_v6
 
 def get_service_netinfo_by_ip(ip):
     return _get_service_info_internal(tablequery.service_resolution(ip=ip))
@@ -59,3 +59,46 @@ def _subdict(src_dict, keys):
             dst_dict[key] = value
 
     return dst_dict
+
+def _format_service_ip(addr_v4=None, addr_v6=None):
+    if addr_v4:
+        return {
+            "Address": addr_v4,
+            "Address_v6": None,
+            "IpType": "IPv4"
+        }
+    elif addr_v6:
+        return {
+            "Address": None,
+            "Address_v6": addr_v6,
+            "IpType": "IPv6"
+        }
+    else:
+        return None
+
+def get_next_x_available_service_ips(x=1, version=None):
+    """
+    Return next x available IPv4 and/or IPv6 addresses formatted per schema.
+    Does not modify the address pool (read-only).
+    """
+    ips = {"available_service_ips": []}
+
+    ipv4_list = []
+    ipv6_list = []
+
+    if version is None:
+        ipv4_list = get_next_available_ip(x)
+        ipv6_list = get_next_available_ip_v6(x)
+    elif version == "v4":
+        ipv4_list = get_next_available_ip(x)
+    elif version == "v6":
+        ipv6_list = get_next_available_ip_v6(x)
+
+
+    for ip in ipv4_list:
+        ips["available_service_ips"].append(_format_service_ip(addr_v4=ip))
+        
+    for ip in ipv6_list:
+        ips["available_service_ips"].append(_format_service_ip(addr_v6=ip))
+
+    return ips

--- a/root-service-manager/service-manager/tests/get_next_available_ip_test.py
+++ b/root-service-manager/service-manager/tests/get_next_available_ip_test.py
@@ -8,7 +8,7 @@ mongodb_client = sys.modules['interfaces.mongodb_requests']
 
 def test_get_available_ip_from_cache():
     # mock mongo db
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=[10, 30, 0, 1])
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[[10, 30, 0, 1]])
     mongodb_client.mongo_get_next_service_ip = MagicMock()
     mongodb_client.mongo_update_next_service_ip = MagicMock()
     mongodb_client.mongo_find_job_by_ip = MagicMock()
@@ -19,7 +19,7 @@ def test_get_available_ip_from_cache():
     assert ips == ["10.30.0.1"]
 
     # verify cache was used and DB was not accessed
-    mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_not_called()
     # verify no modification of state
     mongodb_client.mongo_update_next_service_ip.assert_not_called()
@@ -27,7 +27,7 @@ def test_get_available_ip_from_cache():
 
 def test_get_available_ip_with_cache_miss():
     # mock mongo db
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
 
@@ -37,13 +37,13 @@ def test_get_available_ip_with_cache_miss():
     assert ips == ["10.30.0.1"]
 
     # verify DB was accessed but not modified
-    mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_called_once()
 
 
 def test_get_available_ip_skip_used_ip():
     # mock mongo db with used IP scenario
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
     mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None])
 
@@ -52,8 +52,6 @@ def test_get_available_ip_skip_used_ip():
 
     assert ips == ["10.30.0.2"]
 
-    # verify no modification of state
-    mongodb_client.mongo_update_next_service_ip.assert_not_called()
     # verify IP usage check
     first_call_arg = mongodb_client.mongo_find_job_by_ip.call_args_list[0][0][0]
     assert first_call_arg == "10.30.0.1"
@@ -61,7 +59,7 @@ def test_get_available_ip_skip_used_ip():
 
 def test_get_available_ip_multiple():
     # mock mongo db with used IPs scenario
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
     mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None, None, None])
 
@@ -75,7 +73,7 @@ def test_get_available_ip_multiple():
 
 def test_get_available_ip_exhausted():
     # mock mongo db with exhausted address space
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 253, 253])
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
 
@@ -89,8 +87,8 @@ def test_get_available_ip_exhausted():
 
 def test_get_available_ip_cache_and_db_mix():
     # mock mongo db with multiple cached IPs, then fall back to DB
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(
-        side_effect=[[10, 30, 0, 1], [10, 30, 0, 2], None]
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(
+        return_value=[[10, 30, 0, 1], [10, 30, 0, 2]]
     )
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 3])
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
@@ -101,14 +99,14 @@ def test_get_available_ip_cache_and_db_mix():
     assert ips == ["10.30.0.1", "10.30.0.2", "10.30.0.3"]
 
     # verify both cache and DB were used
-    assert mongodb_client.mongo_get_service_address_from_cache.call_count == 3
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_called_once()
 
 
 def test_get_available_ip_x_greater_than_available():
     # mock mongo db with fewer available IPs than requested
-    mongodb_client.mongo_get_service_address_from_cache = MagicMock(
-        side_effect=[[10, 30, 0, 1], [10, 30, 0, 2], None]
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(
+        return_value=[[10, 30, 0, 1], [10, 30, 0, 2]]
     )
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=None)
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
@@ -119,7 +117,7 @@ def test_get_available_ip_x_greater_than_available():
     assert ips == ["10.30.0.1", "10.30.0.2"]
 
     # verify cache was used and DB attempted
-    assert mongodb_client.mongo_get_service_address_from_cache.call_count == 3
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_called_once()
 
 
@@ -128,8 +126,8 @@ def test_get_available_ip_x_greater_than_available():
 
 def test_get_available_ip_v6_from_cache():
     # mock mongo db
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
-        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(
+        return_value=[[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]]
     )
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock()
     mongodb_client.mongo_find_job_by_ip = MagicMock()
@@ -141,13 +139,13 @@ def test_get_available_ip_v6_from_cache():
     assert ips[0].startswith("fdff")
 
     # verify cache was used and DB was not accessed
-    mongodb_client.mongo_get_service_address_from_cache_v6.assert_called_once()
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6.assert_called_once()
     mongodb_client.mongo_get_next_service_ip_v6.assert_not_called()
 
 
 def test_get_available_ip_v6_with_cache_miss():
     # mock mongo db
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
         return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
     )
@@ -160,13 +158,13 @@ def test_get_available_ip_v6_with_cache_miss():
     assert ips[0].startswith("fdff")
 
     # verify DB was accessed but not modified
-    mongodb_client.mongo_get_service_address_from_cache_v6.assert_called_once()
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6.assert_called_once()
     mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()
 
 
 def test_get_available_ip_v6_skip_used_ip():
     # mock mongo db with used IPv6 scenario
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
         return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
     )
@@ -185,7 +183,7 @@ def test_get_available_ip_v6_skip_used_ip():
 
 def test_get_available_ip_v6_multiple():
     # mock mongo db with multiple IPv6 addresses available
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
         return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
     )
@@ -201,7 +199,7 @@ def test_get_available_ip_v6_multiple():
 
 def test_get_available_ip_v6_exhausted():
     # mock mongo db with exhausted IPv6 address space
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(return_value=None)
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
 
@@ -215,11 +213,11 @@ def test_get_available_ip_v6_exhausted():
 
 def test_get_available_ip_v6_cache_and_db_mix():
     # mock mongo db with multiple cached IPv6 addresses, then fall back to DB
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
-        side_effect=[
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(
+        return_value=[
             [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
             [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
-            None,
+            
         ]
     )
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
@@ -234,18 +232,17 @@ def test_get_available_ip_v6_cache_and_db_mix():
     assert all(ip.startswith("fdff") for ip in ips)
 
     # verify both cache and DB were used
-    assert mongodb_client.mongo_get_service_address_from_cache_v6.call_count == 3
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6.assert_called_once()
     mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()
 
 
 
 def test_get_available_ip_v6_x_greater_than_available():
     # mock mongo db with fewer available IPv6 addresses than requested
-    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
-        side_effect=[
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6 = MagicMock(
+        return_value=[
             [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
-            None,
+            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]
         ]
     )
     mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(return_value=None)
@@ -258,5 +255,5 @@ def test_get_available_ip_v6_x_greater_than_available():
     assert all(ip.startswith("fdff") for ip in ips)
 
     # verify cache was used and DB attempted
-    assert mongodb_client.mongo_get_service_address_from_cache_v6.call_count == 3
+    mongodb_client.mongo_get_service_address_from_cache_not_deleting_v6.assert_called_once()
     mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()

--- a/root-service-manager/service-manager/tests/get_next_available_ip_test.py
+++ b/root-service-manager/service-manager/tests/get_next_available_ip_test.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock
 import sys
-from network.subnetwork_management import get_next_available_ip
+from network.subnetwork_management import get_next_available_ip, get_next_available_ip_v6
 
 mongodb_client = sys.modules['interfaces.mongodb_requests']
+
+####################### IPv4 TESTS
 
 def test_get_available_ip_from_cache():
     # mock mongo db
@@ -10,83 +12,251 @@ def test_get_available_ip_from_cache():
     mongodb_client.mongo_get_next_service_ip = MagicMock()
     mongodb_client.mongo_update_next_service_ip = MagicMock()
     mongodb_client.mongo_find_job_by_ip = MagicMock()
-    
-    # test address retrieval from cache
-    ip = get_next_available_ip()
 
-    assert ip == "10.30.0.1"
-    
+    # test address retrieval from cache
+    ips = get_next_available_ip()
+
+    assert ips == ["10.30.0.1"]
+
     # verify cache was used and DB was not accessed
     mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_not_called()
     # verify no modification of state
     mongodb_client.mongo_update_next_service_ip.assert_not_called()
 
+
 def test_get_available_ip_with_cache_miss():
     # mock mongo db
     mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
-    mongodb_client.mongo_update_next_service_ip = MagicMock()
-    
-    # test address retrieval from DB
-    ip = get_next_available_ip()
 
-    assert ip == "10.30.0.1"
-    
+    # test address retrieval from DB after cache miss
+    ips = get_next_available_ip()
+
+    assert ips == ["10.30.0.1"]
+
     # verify DB was accessed but not modified
     mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
     mongodb_client.mongo_get_next_service_ip.assert_called_once()
-    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+
 
 def test_get_available_ip_skip_used_ip():
     # mock mongo db with used IP scenario
     mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
-    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "test"}, None])
-    mongodb_client.mongo_update_next_service_ip = MagicMock()
-    
-    # test address retrieval skipping used IP
-    ip =get_next_available_ip()
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None])
 
-    assert ip == "10.30.0.2"
-    
+    # test address retrieval skipping used IP
+    ips = get_next_available_ip()
+
+    assert ips == ["10.30.0.2"]
+
     # verify no modification of state
     mongodb_client.mongo_update_next_service_ip.assert_not_called()
     # verify IP usage check
-    first_call_args = mongodb_client.mongo_find_job_by_ip.call_args_list[0]
-    assert first_call_args[0][0] == [10, 30, 0, 1]
+    first_call_arg = mongodb_client.mongo_find_job_by_ip.call_args_list[0][0][0]
+    assert first_call_arg == "10.30.0.1"
 
-def test_get_available_ip_multiple_calls():
+
+def test_get_available_ip_multiple():
     # mock mongo db with used IPs scenario
     mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
-    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "test"}, None, {"job_name": "test"}, None])
-    mongodb_client.mongo_update_next_service_ip = MagicMock()
-    
-    # Multiple calls should return the same IP without modifying state
-    ip1 = get_next_available_ip()
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None, None, None])
 
-    assert ip1 == "10.30.0.2"
+    # test retrieval of multiple available IPs
+    ips = get_next_available_ip(3)
 
-    ip2 = get_next_available_ip()
+    assert ips == ["10.30.0.2", "10.30.0.3", "10.30.0.4"]
 
-    assert ip2 == "10.30.0.2"
-    
-    # verify no modification of state between calls
-    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+
+
 
 def test_get_available_ip_exhausted():
     # mock mongo db with exhausted address space
     mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 253, 253])
     mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
-    mongodb_client.mongo_update_next_service_ip = MagicMock()
-    
-    # test address space exhaustion detection
-    ip = get_next_available_ip()
 
-    assert ip is None
-    
-    # verify no modification even in error case
-    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+    # test address space exhaustion detection
+    ips = get_next_available_ip()
+
+    assert ips == []
+
+
+
+
+def test_get_available_ip_cache_and_db_mix():
+    # mock mongo db with multiple cached IPs, then fall back to DB
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(
+        side_effect=[[10, 30, 0, 1], [10, 30, 0, 2], None]
+    )
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 3])
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test retrieval of multiple IPs from cache and DB
+    ips = get_next_available_ip(3)
+
+    assert ips == ["10.30.0.1", "10.30.0.2", "10.30.0.3"]
+
+    # verify both cache and DB were used
+    assert mongodb_client.mongo_get_service_address_from_cache.call_count == 3
+    mongodb_client.mongo_get_next_service_ip.assert_called_once()
+
+
+def test_get_available_ip_x_greater_than_available():
+    # mock mongo db with fewer available IPs than requested
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(
+        side_effect=[[10, 30, 0, 1], [10, 30, 0, 2], None]
+    )
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=None)
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test when requested count (x) exceeds available IPs
+    ips = get_next_available_ip(5)
+
+    assert ips == ["10.30.0.1", "10.30.0.2"]
+
+    # verify cache was used and DB attempted
+    assert mongodb_client.mongo_get_service_address_from_cache.call_count == 3
+    mongodb_client.mongo_get_next_service_ip.assert_called_once()
+
+
+####################### IPv6 TESTS
+
+
+def test_get_available_ip_v6_from_cache():
+    # mock mongo db
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
+        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    )
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock()
+    mongodb_client.mongo_find_job_by_ip = MagicMock()
+
+    # test address retrieval from cache
+    ips = get_next_available_ip_v6()
+
+    assert len(ips) == 1
+    assert ips[0].startswith("fdff")
+
+    # verify cache was used and DB was not accessed
+    mongodb_client.mongo_get_service_address_from_cache_v6.assert_called_once()
+    mongodb_client.mongo_get_next_service_ip_v6.assert_not_called()
+
+
+def test_get_available_ip_v6_with_cache_miss():
+    # mock mongo db
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
+        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    )
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test retrieval from DB after cache miss
+    ips = get_next_available_ip_v6()
+
+    assert len(ips) == 1
+    assert ips[0].startswith("fdff")
+
+    # verify DB was accessed but not modified
+    mongodb_client.mongo_get_service_address_from_cache_v6.assert_called_once()
+    mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()
+
+
+def test_get_available_ip_v6_skip_used_ip():
+    # mock mongo db with used IPv6 scenario
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
+        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    )
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None])
+
+    # test skipping a used IPv6 address
+    ips = get_next_available_ip_v6()
+
+    assert len(ips) == 1
+    assert ips[0].startswith("fdff")
+
+    # verify IP usage check
+    first_call_arg = mongodb_client.mongo_find_job_by_ip.call_args_list[0][0][0]
+    assert isinstance(first_call_arg, str) and first_call_arg.startswith("fdff")
+
+
+def test_get_available_ip_v6_multiple():
+    # mock mongo db with multiple IPv6 addresses available
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
+        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+    )
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "used"}, None, None, None])
+
+    # test retrieval of multiple IPv6 addresses
+    ips = get_next_available_ip_v6(3)
+
+    assert len(ips) == 3
+    assert all(ip.startswith("fdff") for ip in ips)
+
+
+
+def test_get_available_ip_v6_exhausted():
+    # mock mongo db with exhausted IPv6 address space
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test exhaustion case
+    ips = get_next_available_ip_v6()
+
+    assert ips == []
+
+
+
+
+def test_get_available_ip_v6_cache_and_db_mix():
+    # mock mongo db with multiple cached IPv6 addresses, then fall back to DB
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
+        side_effect=[
+            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+            None,
+        ]
+    )
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(
+        return_value=[253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3]
+    )
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test retrieval of multiple IPv6 addresses from cache and DB
+    ips = get_next_available_ip_v6(3)
+
+    assert len(ips) == 3
+    assert all(ip.startswith("fdff") for ip in ips)
+
+    # verify both cache and DB were used
+    assert mongodb_client.mongo_get_service_address_from_cache_v6.call_count == 3
+    mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()
+
+
+
+def test_get_available_ip_v6_x_greater_than_available():
+    # mock mongo db with fewer available IPv6 addresses than requested
+    mongodb_client.mongo_get_service_address_from_cache_v6 = MagicMock(
+        side_effect=[
+            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            [253, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+            None,
+        ]
+    )
+    mongodb_client.mongo_get_next_service_ip_v6 = MagicMock(return_value=None)
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+
+    # test when requested count (x) exceeds available IPv6 addresses
+    ips = get_next_available_ip_v6(5)
+
+    assert len(ips) == 2
+    assert all(ip.startswith("fdff") for ip in ips)
+
+    # verify cache was used and DB attempted
+    assert mongodb_client.mongo_get_service_address_from_cache_v6.call_count == 3
+    mongodb_client.mongo_get_next_service_ip_v6.assert_called_once()

--- a/root-service-manager/service-manager/tests/get_next_available_ip_test.py
+++ b/root-service-manager/service-manager/tests/get_next_available_ip_test.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock
+import sys
+from network.subnetwork_management import get_next_available_ip
+
+mongodb_client = sys.modules['interfaces.mongodb_requests']
+
+def test_get_available_ip_from_cache():
+    # mock mongo db
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=[10, 30, 0, 1])
+    mongodb_client.mongo_get_next_service_ip = MagicMock()
+    mongodb_client.mongo_update_next_service_ip = MagicMock()
+    mongodb_client.mongo_find_job_by_ip = MagicMock()
+    
+    # test address retrieval from cache
+    ip = get_next_available_ip()
+
+    assert ip == "10.30.0.1"
+    
+    # verify cache was used and DB was not accessed
+    mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
+    mongodb_client.mongo_get_next_service_ip.assert_not_called()
+    # verify no modification of state
+    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+
+def test_get_available_ip_with_cache_miss():
+    # mock mongo db
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+    mongodb_client.mongo_update_next_service_ip = MagicMock()
+    
+    # test address retrieval from DB
+    ip = get_next_available_ip()
+
+    assert ip == "10.30.0.1"
+    
+    # verify DB was accessed but not modified
+    mongodb_client.mongo_get_service_address_from_cache.assert_called_once()
+    mongodb_client.mongo_get_next_service_ip.assert_called_once()
+    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+
+def test_get_available_ip_skip_used_ip():
+    # mock mongo db with used IP scenario
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "test"}, None])
+    mongodb_client.mongo_update_next_service_ip = MagicMock()
+    
+    # test address retrieval skipping used IP
+    ip =get_next_available_ip()
+
+    assert ip == "10.30.0.2"
+    
+    # verify no modification of state
+    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+    # verify IP usage check
+    first_call_args = mongodb_client.mongo_find_job_by_ip.call_args_list[0]
+    assert first_call_args[0][0] == [10, 30, 0, 1]
+
+def test_get_available_ip_multiple_calls():
+    # mock mongo db with used IPs scenario
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 0, 1])
+    mongodb_client.mongo_find_job_by_ip = MagicMock(side_effect=[{"job_name": "test"}, None, {"job_name": "test"}, None])
+    mongodb_client.mongo_update_next_service_ip = MagicMock()
+    
+    # Multiple calls should return the same IP without modifying state
+    ip1 = get_next_available_ip()
+
+    assert ip1 == "10.30.0.2"
+
+    ip2 = get_next_available_ip()
+
+    assert ip2 == "10.30.0.2"
+    
+    # verify no modification of state between calls
+    mongodb_client.mongo_update_next_service_ip.assert_not_called()
+
+def test_get_available_ip_exhausted():
+    # mock mongo db with exhausted address space
+    mongodb_client.mongo_get_service_address_from_cache = MagicMock(return_value=None)
+    mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 253, 253])
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+    mongodb_client.mongo_update_next_service_ip = MagicMock()
+    
+    # test address space exhaustion detection
+    ip = get_next_available_ip()
+
+    assert ip is None
+    
+    # verify no modification even in error case
+    mongodb_client.mongo_update_next_service_ip.assert_not_called()

--- a/root-service-manager/service-manager/tests/get_next_available_ip_test.py
+++ b/root-service-manager/service-manager/tests/get_next_available_ip_test.py
@@ -75,7 +75,7 @@ def test_get_available_ip_exhausted():
     # mock mongo db with exhausted address space
     mongodb_client.mongo_get_service_address_from_cache_not_deleting = MagicMock(return_value=[])
     mongodb_client.mongo_get_next_service_ip = MagicMock(return_value=[10, 30, 253, 253])
-    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value=None)
+    mongodb_client.mongo_find_job_by_ip = MagicMock(return_value={"job_name": "used"})
 
     # test address space exhaustion detection
     ips = get_next_available_ip()


### PR DESCRIPTION
Fixes #219 

Created function get_next_available_ip() using the same logic that new_instance_ip but without calling mongo_update_next_service_ip() in the database so it's idempotent (c  calling it multiple times under the same conditions returns the same IP). 
Added the endpoint /available-ip in netinfo_blueprints. 
The function was placed in subnetwork_management and imported it in netinfo_blueprints because it was only one function, but optionally it could be moved to tablequery and then call it in netinfo_management.
