### PR TITLE
fix: correct off-by-one in ProxyCache and value-receiver bugs causing broken mutex and eviction

### DIFF
--- a/node-net-manager/proxy/ProxySetup.go
+++ b/node-net-manager/proxy/ProxySetup.go
@@ -18,7 +18,7 @@ import (
 )
 
 // create a  new GoProxyTunnel with the configuration from the custom local file
-func New() GoProxyTunnel {
+func New() *GoProxyTunnel {
 	// load netcfg.json
 	cfg, err := os.Open("/etc/netmanager/tuncfg.json")
 	if err != nil {
@@ -48,7 +48,7 @@ func New() GoProxyTunnel {
 }
 
 // create a  new GoProxyTunnel with a custom configuration
-func NewCustom(configuration Configuration) GoProxyTunnel {
+func NewCustom(configuration Configuration) *GoProxyTunnel {
 	proxy := GoProxyTunnel{
 		isListening:      false,
 		errorChannel:     make(chan error),
@@ -89,7 +89,7 @@ func NewCustom(configuration Configuration) GoProxyTunnel {
 	logger.InfoLogger().Printf("Created ProxyTun device: %s\n", proxy.ifce.Name())
 	logger.InfoLogger().Printf("Local Ip detected: %s\n", proxy.localIP.String())
 
-	return proxy
+	return &proxy
 }
 
 func (proxy *GoProxyTunnel) SetEnvironment(env env.EnvironmentManager) {

--- a/node-net-manager/proxy/ProxySetup.go
+++ b/node-net-manager/proxy/ProxySetup.go
@@ -23,8 +23,9 @@ func New() *GoProxyTunnel {
 	cfg, err := os.Open("/etc/netmanager/tuncfg.json")
 	if err != nil {
 		logger.ErrorLogger().Println(err)
+	} else {
+		defer cfg.Close()
 	}
-	defer cfg.Close()
 
 	defaultconfig := Configuration{
 		HostTUNDeviceName:         "goProxyTun",

--- a/node-net-manager/proxy/ProxyTunnel.go
+++ b/node-net-manager/proxy/ProxyTunnel.go
@@ -49,7 +49,7 @@ type GoProxyTunnel struct {
 	ProxyIpSubnetwork   net.IPNet
 	ProxyIPv6Subnetwork net.IPNet
 	localIP             net.IP
-	proxycache          ProxyCache
+	proxycache          *ProxyCache
 	TunnelPort          int
 	bufferPort          int
 	udpwrite            sync.RWMutex

--- a/node-net-manager/proxy/Proxy_test.go
+++ b/node-net-manager/proxy/Proxy_test.go
@@ -77,8 +77,8 @@ func (fakeenv *FakeEnv) GetTableEntryByInstanceIP(ip net.IP) (TableEntryCache.Ta
 	return TableEntryCache.TableEntry{}, false
 }
 
-func getFakeTunnel() GoProxyTunnel {
-	tunnel := GoProxyTunnel{
+func getFakeTunnel() *GoProxyTunnel {
+	tunnel := &GoProxyTunnel{
 		tunNetIP:    "10.19.1.254",
 		ifce:        nil,
 		isListening: true,

--- a/node-net-manager/proxy/proxyCache.go
+++ b/node-net-manager/proxy/proxyCache.go
@@ -29,11 +29,10 @@ type ProxyCache struct {
 	rwlock                sync.RWMutex
 }
 
-func NewProxyCache() ProxyCache {
-	cache := ProxyCache{
-		cache:                 make([]ConversionList, 65535),
+func NewProxyCache() *ProxyCache {
+	cache := &ProxyCache{
+		cache:                 make([]ConversionList, 65536),
 		conversionListMaxSize: 10,
-		rwlock:                sync.RWMutex{},
 	}
 	cache.runEvictionJob(30*time.Second, 1*time.Minute)
 	return cache

--- a/node-net-manager/proxy/proxyCache.go
+++ b/node-net-manager/proxy/proxyCache.go
@@ -4,6 +4,7 @@ import (
 	"NetManager/logger"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,7 +19,7 @@ type ConversionEntry struct {
 
 type ConversionList struct {
 	nextEntry      int
-	lastUsed       int64
+	lastUsed       atomic.Int64
 	conversionList []ConversionEntry
 }
 
@@ -56,11 +57,12 @@ func (cache *ProxyCache) evictOldEntries(timeout time.Duration) {
 	now := time.Now().Unix()
 	timeoutSeconds := int64(timeout.Seconds())
 	evictedCount := 0
-	for i, elem := range cache.cache {
-		// An entry is considered old if it has not been used for the timeout period.
-		if elem.lastUsed != 0 && (now-elem.lastUsed) > timeoutSeconds {
-			// To evict the entry, we just reset it to its zero value.
-			cache.cache[i] = ConversionList{}
+	for i := range cache.cache {
+		lastUsed := cache.cache[i].lastUsed.Load()
+		if lastUsed != 0 && (now-lastUsed) > timeoutSeconds {
+			cache.cache[i].lastUsed.Store(0)
+			cache.cache[i].nextEntry = 0
+			cache.cache[i].conversionList = nil
 			evictedCount++
 		}
 	}
@@ -71,8 +73,8 @@ func (cache *ProxyCache) evictOldEntries(timeout time.Duration) {
 
 // RetrieveByServiceIP Retrieve proxy proxycache entry based on source ip and source port and destination ServiceIP
 func (cache *ProxyCache) RetrieveByServiceIP(srcip net.IP, instanceIP net.IP, srcport int, dstServiceIp net.IP, dstport int) (ConversionEntry, bool) {
-	cache.rwlock.Lock()
-	defer cache.rwlock.Unlock()
+	cache.rwlock.RLock()
+	defer cache.rwlock.RUnlock()
 
 	elem := &cache.cache[srcport]
 	if elem.conversionList != nil {
@@ -81,7 +83,7 @@ func (cache *ProxyCache) RetrieveByServiceIP(srcip net.IP, instanceIP net.IP, sr
 				cacheEntry.dstServiceIp.Equal(dstServiceIp) &&
 				cacheEntry.srcip.Equal(srcip) &&
 				cacheEntry.srcInstanceIp.Equal(instanceIP) {
-				elem.lastUsed = time.Now().Unix()
+				elem.lastUsed.Store(time.Now().Unix())
 				return cacheEntry, true
 			}
 		}
@@ -91,14 +93,14 @@ func (cache *ProxyCache) RetrieveByServiceIP(srcip net.IP, instanceIP net.IP, sr
 
 // RetrieveByInstanceIp Retrieve proxy proxycache entry based on source ip and source port and destination ip
 func (cache *ProxyCache) RetrieveByInstanceIp(srcip net.IP, srcport int, dstport int) (ConversionEntry, bool) {
-	cache.rwlock.Lock()
-	defer cache.rwlock.Unlock()
+	cache.rwlock.RLock()
+	defer cache.rwlock.RUnlock()
 
 	elem := &cache.cache[srcport]
 	if elem.conversionList != nil {
 		for _, entry := range elem.conversionList {
 			if entry.dstport == dstport && entry.srcip.Equal(srcip) {
-				elem.lastUsed = time.Now().Unix()
+				elem.lastUsed.Store(time.Now().Unix())
 				return entry, true
 			}
 		}
@@ -122,7 +124,7 @@ func (cache *ProxyCache) Add(entry ConversionEntry) {
 
 func (cache *ProxyCache) addToConversionList(entry ConversionEntry) {
 	elem := &cache.cache[entry.srcport]
-	elem.lastUsed = time.Now().Unix()
+	elem.lastUsed.Store(time.Now().Unix())
 	alreadyExist := false
 	alreadyExistPosition := 0
 	//check if used port is already in proxycache

--- a/node-net-manager/proxy/proxyCache.go
+++ b/node-net-manager/proxy/proxyCache.go
@@ -18,7 +18,10 @@ type ConversionEntry struct {
 }
 
 type ConversionList struct {
-	nextEntry      int
+	nextEntry int
+	// lastUsed holds a Unix timestamp (seconds since epoch, as from time.Now().Unix()).
+	// It is atomic so retrieve methods can update it while holding only the
+	// cache's read lock (RLock), instead of requiring a write lock.
 	lastUsed       atomic.Int64
 	conversionList []ConversionEntry
 }

--- a/node-net-manager/server/server.go
+++ b/node-net-manager/server/server.go
@@ -84,7 +84,7 @@ func HandleRequests(port int) {
 
 var (
 	Env   env.Environment
-	Proxy proxy.GoProxyTunnel
+	Proxy *proxy.GoProxyTunnel
 )
 
 /*
@@ -107,6 +107,7 @@ func register(writer http.ResponseWriter, request *http.Request) {
 	err := json.Unmarshal(reqBody, &requestStruct)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	log.Println(requestStruct)
 


### PR DESCRIPTION
### Bug Fixes

**Off-by-one in `ProxyCache` allocation**

`NewProxyCache` allocated `make([]ConversionList, 65535)`, giving valid indices `0–65534`. Port `65535` is explicitly allowed by the bounds check in `Nat.go` (`portInt > 65535`), so accessing the cache at that port would panic with an out-of-bounds index. Fixed by allocating `65536` entries to cover the full valid port range `[0, 65535]`.

**Value receivers breaking mutex and eviction**

`NewProxyCache()`, `New()`, and `NewCustom()` returned struct values instead of pointers. This caused two distinct problems:

- The embedded `sync.RWMutex` was copied on return, making mutual exclusion ineffective. `go vet` reports this as a `copylocks` violation.
- In `NewProxyCache()`, `runEvictionJob()` was called on the local value before the return, so the eviction goroutine held a reference to a separate, abandoned `ProxyCache` instance while the caller received a freshly initialized one. Eviction was effectively disabled: the goroutine was evicting from a cache no one could write to.

Both are fixed by returning pointers and storing `*ProxyCache` in `GoProxyTunnel`.

**Missing early return in request handler**

`server.go` continued processing after writing `StatusBadRequest` when JSON unmarshalling failed. Added a `return` to prevent operating on an uninitialized request struct.

### Performance Improvements

Read-only lookups (`RetrieveByServiceIP`, `RetrieveByInstanceIp`) previously acquired a full write lock, unnecessarily serializing concurrent reads. These now use `RLock`/`RUnlock`.

Since `lastUsed` is now written inside a read lock (by the retrieve methods) and read by the eviction goroutine without any lock, it is changed from a plain `int64` to `sync/atomic.Int64`, ensuring safe concurrent access without requiring a write lock for timestamp updates.
