### PR TITLE
fix: typo in IptableFlushAll and switch to os.WriteFile

### DIFF
--- a/node-net-manager/network/Nat.go
+++ b/node-net-manager/network/Nat.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -37,27 +38,17 @@ func IptableFlushAll() {
 
 func DisableReversePathFiltering(bridgeName string) {
 	log.Println("disabling reverse path filtering")
-	cmd := exec.Command("echo", "0", ">", "/proc/sys/net/ipv4/conf/all/rp_filter")
-	err := cmd.Run()
-	if err != nil {
+	if err := os.WriteFile("/proc/sys/net/ipv4/conf/all/rp_filter", []byte("0"), 0644); err != nil {
 		log.Fatal(err.Error())
 	}
 	log.Println("enabling IP forwarding")
-	cmd = exec.Command("sysctl", "-w", "net.ipv4.ip_forward=1")
-	err = cmd.Run()
-	if err != nil {
+	if err := exec.Command("sysctl", "-w", "net.ipv4.ip_forward=1").Run(); err != nil {
 		log.Fatal(err.Error())
 	}
-
-	cmd = exec.Command("sysctl", "-w", "net.ipv6.conf.all.forwarding=1")
-	err = cmd.Run()
-	if err != nil {
+	if err := exec.Command("sysctl", "-w", "net.ipv6.conf.all.forwarding=1").Run(); err != nil {
 		log.Fatal(err.Error())
 	}
-
-	cmd = exec.Command("echo", "0", ">", "/proc/sys/net/ipv4/conf/"+bridgeName+"/rp_filter")
-	err = cmd.Run()
-	if err != nil {
+	if err := os.WriteFile("/proc/sys/net/ipv4/conf/"+bridgeName+"/rp_filter", []byte("0"), 0644); err != nil {
 		log.Fatal(err.Error())
 	}
 }

--- a/node-net-manager/network/Nat.go
+++ b/node-net-manager/network/Nat.go
@@ -32,7 +32,7 @@ func IptableFlushAll() {
 	_ = iptable.Delete("nat", "POSTROUTING", "-j", chain)
 	_ = ip6table.DeleteChain("nat", chain)
 	_ = ip6table.Delete("nat", "PREROUTING", "-j", chain)
-	_ = ip6table.Delete("nat", "PREROUTING", "-j", chain)
+	_ = ip6table.Delete("nat", "POSTROUTING", "-j", chain)
 }
 
 func DisableReversePathFiltering(bridgeName string) {


### PR DESCRIPTION
**System command and file handling improvements:**

* Refactored `DisableReversePathFiltering` to use `os.WriteFile` for writing directly to `/proc/sys/net/ipv4/conf/all/rp_filter` and `/proc/sys/net/ipv4/conf/<bridgeName>/rp_filter`, replacing the less reliable use of `exec.Command` with `echo`
* Streamlined the execution of `sysctl` commands by removing redundant variable assignments, improving code readability and error handling.

**Bug fix in ip6tables rule deletion:**

* Fixed a bug in `IptableFlushAll` by correcting the chain name in the ip6tables `Delete` call from `PREROUTING` to `POSTROUTING`, ensuring proper cleanup of NAT rules.