### PR TITLE
fix: return error when no default route is found

### DIFF
--- a/node-net-manager/network/NetUtils.go
+++ b/node-net-manager/network/NetUtils.go
@@ -95,7 +95,7 @@ func defaultRoute() (*netlink.Link, error) {
 	}
 
 	if len(routes) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("no default route found")
 	}
 
 	if n := len(routes); n > 1 {


### PR DESCRIPTION
This pull request updates the `defaultRoute` function in `NetUtils.go` to improve error handling when no default route is found. Instead of returning `nil`, the function now returns a descriptive error.
