### PR TITLE
fix: missing return statements in deployment methods

### DIFF
--- a/node-net-manager/handlers/ContainerManager.go
+++ b/node-net-manager/handlers/ContainerManager.go
@@ -74,6 +74,7 @@ func (m *ContainerManager) containerDeploy(writer http.ResponseWriter, request *
 	err := json.Unmarshal(reqBody, &deployTask)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	deployTask.Runtime = env.CONTAINER_RUNTIME
 	deployTask.PublicAddr = m.Configuration.NodePublicAddress
@@ -134,6 +135,7 @@ func (m *ContainerManager) containerUndeploy(writer http.ResponseWriter, request
 	err := json.Unmarshal(reqBody, &requestStruct)
 	if err != nil {
 		writer.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	log.Println(requestStruct)


### PR DESCRIPTION
This pull request introduces small but important error handling improvements to the `ContainerManager` HTTP handlers. Specifically, it ensures that the handler functions return immediately after writing a `400 Bad Request` status if the request payload cannot be unmarshaled, preventing any further processing in error scenarios.