### PR TITLE
refactor: SliceAPI implementation to use generics

### DIFF
--- a/node-net-manager/mqtt/MqttJobUpdates.go
+++ b/node-net-manager/mqtt/MqttJobUpdates.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var runningHandlers = utils.NewStringSlice()
+var runningHandlers = utils.NewSlice[string]()
 var runningHandlersLock sync.RWMutex
 
 type jobUpdatesTimer struct {

--- a/node-net-manager/utils/SliceApi.go
+++ b/node-net-manager/utils/SliceApi.go
@@ -4,51 +4,65 @@ import (
 	"sync"
 )
 
-type stringSlice struct {
-	slice []string
-	mutex sync.Mutex
+type genericSlice[T comparable] struct {
+	data  []T
+	mutex sync.RWMutex
 }
 
-type StringSlice interface {
-	Add(elem string)
-	RemoveElem(elem string)
+type Slice[T comparable] interface {
+	Add(elem T)
+	RemoveElem(elem T)
 	Remove(index int)
-	Find(elem string) int
-	Get() []string
-	Exists(elem string) bool
+	Find(elem T) int
+	Get() []T
+	Exists(elem T) bool
 }
 
-func NewStringSlice() StringSlice {
-	return &stringSlice{
-		slice: make([]string, 0),
-		mutex: sync.Mutex{},
+func NewSlice[T comparable]() Slice[T] {
+	return &genericSlice[T]{
+		data: make([]T, 0),
 	}
 }
 
-func (s *stringSlice) Add(elem string) {
+func (s *genericSlice[T]) Add(elem T) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	s.slice = append(s.slice, elem)
+	s.data = append(s.data, elem)
 }
 
-func (s *stringSlice) Remove(index int) {
+func (s *genericSlice[T]) Remove(index int) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	if index >= 0 && index < len(s.slice) {
-		s.slice[index] = s.slice[len(s.slice)-1]
-		s.slice = s.slice[:len(s.slice)-1]
-	}
+	s.removeLocked(index)
 }
 
-func (s *stringSlice) RemoveElem(elem string) {
-	position := s.Find(elem)
-	s.Remove(position)
-}
-
-func (s *stringSlice) Find(elem string) int {
+func (s *genericSlice[T]) RemoveElem(elem T) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	for index, currentElem := range s.slice {
+	s.removeLocked(s.findLocked(elem))
+}
+
+func (s *genericSlice[T]) Find(elem T) int {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.findLocked(elem)
+}
+
+func (s *genericSlice[T]) Exists(elem T) bool {
+	return s.Find(elem) >= 0
+}
+
+func (s *genericSlice[T]) Get() []T {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	result := make([]T, len(s.data))
+	copy(result, s.data)
+	return result
+}
+
+// caller must hold at least a read lock
+func (s *genericSlice[T]) findLocked(elem T) int {
+	for index, currentElem := range s.data {
 		if currentElem == elem {
 			return index
 		}
@@ -56,10 +70,10 @@ func (s *stringSlice) Find(elem string) int {
 	return -1
 }
 
-func (s *stringSlice) Exists(elem string) bool {
-	return s.Find(elem) >= 0
-}
-
-func (s *stringSlice) Get() []string {
-	return s.slice
+// caller must hold the write lock; swaps the target with the last element to avoid shifting
+func (s *genericSlice[T]) removeLocked(index int) {
+	if index >= 0 && index < len(s.data) {
+		s.data[index] = s.data[len(s.data)-1]
+		s.data = s.data[:len(s.data)-1]
+	}
 }

--- a/node-net-manager/utils/SliceApi_test.go
+++ b/node-net-manager/utils/SliceApi_test.go
@@ -3,7 +3,7 @@ package utils
 import "testing"
 
 func TestStringSlice_Add(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("test")
 	slice := s.Get()
 	for _, s := range slice {
@@ -15,7 +15,7 @@ func TestStringSlice_Add(t *testing.T) {
 }
 
 func TestStringSlice_Exists(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("test")
 	if s.Exists("mario") {
 		t.Error("mario should not be in the slice")
@@ -26,7 +26,7 @@ func TestStringSlice_Exists(t *testing.T) {
 }
 
 func TestStringSlice_Find(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("0")
 	s.Add("1")
 	index := s.Find("0")
@@ -40,7 +40,7 @@ func TestStringSlice_Find(t *testing.T) {
 }
 
 func TestStringSlice_Remove(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("m")
 	s.Remove(0)
 	if len(s.Get()) > 0 {
@@ -49,7 +49,7 @@ func TestStringSlice_Remove(t *testing.T) {
 }
 
 func TestStringSlice_Remove2(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("a")
 	s.Add("m")
 	s.Add("n")
@@ -63,7 +63,7 @@ func TestStringSlice_Remove2(t *testing.T) {
 }
 
 func TestStringSlice_RemoveElem(t *testing.T) {
-	s := NewStringSlice()
+	s := NewSlice[string]()
 	s.Add("a")
 	s.Add("m")
 	s.Add("n")


### PR DESCRIPTION
I love generics. When I saw this `utils` implementation, I couldn't resist 😬

I refactored the `StringSlice` utility to a generic, thread-safe `Slice` type, allowing it to handle any comparable type, not just strings. I updated the implementation to use Go generics, improves concurrency handling by switching to `sync.RWMutex`, and updated all usages and tests accordingly.