### PR TITLE
Add OneShot pipeline to Oakestra Net

### DIFF
--- a/.github/actions/awx-deploy/action.yml
+++ b/.github/actions/awx-deploy/action.yml
@@ -1,0 +1,34 @@
+name: "AWX Deployment Trigger"
+description: "Triggers a deployment on Ansible AWX and waits for the result"
+
+inputs:
+  AWX_URL:
+    description: "The URL for the Ansible AWX instance"
+    required: true
+  AWX_TOKEN:
+    description: "The API token for authenticating with AWX"
+    required: true
+  AWX_TEMPLATE_ID:
+    description: "The Job Template ID to trigger in AWX"
+    required: true
+  PR_USER:
+    description: "The user who opened the PR that triggered the deployment"
+    required: true
+  PR_NET_BRANCH:
+    description: "The oakestra-net branch of the PR that triggered the deployment"
+    required: true
+  PR_NET_COMMIT:
+    description: "The oakestra-net commit SHA of the PR that triggered the deployment"
+    required: true
+  OAK_BRANCH:
+    description: "The oakestra repository branch to test the PR against"
+    required: false
+    default: "develop"
+  OAK_COMMIT:
+    description: "The oakestra repository commit to test the PR against"
+    required: false
+    default: "HEAD"
+
+runs:
+  using: "node24"
+  main: "index.js"

--- a/.github/actions/awx-deploy/index.js
+++ b/.github/actions/awx-deploy/index.js
@@ -1,0 +1,76 @@
+import * as core from '@actions/core';
+import axios from 'axios';
+import https from 'https';
+import sslRootCAs from 'ssl-root-cas';
+
+https.globalAgent.options.ca = sslRootCAs.create();
+
+const POLL_INTERVAL_MS = 60_000;
+const TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+async function triggerAWX() {
+  try {
+    const awxUrl = core.getInput('AWX_URL');
+    const token = core.getInput('AWX_TOKEN');
+    const workflowTemplateId = core.getInput('AWX_TEMPLATE_ID');
+    const netBranch = core.getInput('PR_NET_BRANCH');
+    const netCommit = core.getInput('PR_NET_COMMIT');
+    const pullRequestUser = core.getInput('PR_USER');
+    const oakBranch = core.getInput('OAK_BRANCH');
+    const oakCommit = core.getInput('OAK_COMMIT');
+
+    const headers = {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+
+    const extraVars = {
+      oak_repo_branch: oakBranch,
+      oak_repo_commit: oakCommit,
+      oak_branch: oakBranch, //compatibility with oak custom workflow
+      oak_commit: oakCommit, //compatibility with oak custom workflow
+      oak_net_branch: netBranch,
+      oak_net_commit: netCommit,
+      pr_fork_user: pullRequestUser
+    };
+
+    core.info(`🌱 Oakestra-net branch: ${netBranch}`);
+    core.info(`#️⃣ Oakestra-net commit: ${netCommit}`);
+    core.info(`🌳 Tested against oakestra branch: ${oakBranch} (${oakCommit})`);
+    core.info(`👷 PR Commit Author: ${pullRequestUser}`);
+
+    // Step 1: Trigger the workflow job template
+    const jobLaunchUrl = `https://${awxUrl}/api/v2/workflow_job_templates/${workflowTemplateId}/launch/`;
+    const response = await axios.post(jobLaunchUrl, { extra_vars: extraVars }, { headers });
+
+    const jobId = response.data.workflow_job;
+    core.info(`🆔 Execution ID: ${jobId}`);
+
+    // Step 2: Poll the job status until terminal state or timeout
+    const jobStatusUrl = `https://${awxUrl}/api/v2/workflow_jobs/${jobId}/`;
+    const deadline = Date.now() + TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      const jobResponse = await axios.get(jobStatusUrl, { headers });
+      const status = jobResponse.data.status;
+
+      core.info(`⚙️ Current job status: ${status} ⏳`);
+
+      if (status === 'successful') {
+        core.info('🎉 ✅ 🎉  Tests passed successfully! 🎉 ✅ 🎉');
+        return;
+      } else if (['failed', 'error', 'canceled'].includes(status)) {
+        throw new Error(` 🔴 Tests execution failed with status: ${status} 🔴 `);
+      }
+
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+
+    throw new Error('Timed out waiting for AWX job to reach a terminal state');
+
+  } catch (error) {
+    core.setFailed(`Action failed: ${error.message}`);
+  }
+}
+
+triggerAWX();

--- a/.github/actions/awx-deploy/package.json
+++ b/.github/actions/awx-deploy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "awx-deploy-action",
+  "version": "1.0.0",
+  "description": "Trigger AWX Oneshot Testbed for Oakestra-net Automated Testing",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "TheDarkPyotr",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.3.5",
+    "@actions/core": "^3.0.1",
+    "ssl-root-cas": "^1.3.1"
+  }
+}

--- a/.github/workflows/oneshot_testbed_approval.yml
+++ b/.github/workflows/oneshot_testbed_approval.yml
@@ -1,0 +1,64 @@
+name: Testbed Oneshot - Intermediate Approval Check
+
+# This action validates the PR approval before initiating the testbed deployment.
+# It triggers the deployment through the `oneshot_testbed_workflow_run` action.
+# By decoupling the deployment process from the waiting cycle, this setup allows external forks to execute
+# without passing any sensitive secrets or execution rights to the forked repository.
+# The `oneshot_testbed_workflow_run` action handles the testbed deployment and reports the outcome (success or failure).
+
+
+on:
+    pull_request_review:
+      types: [submitted]
+
+jobs:
+  check:
+    name: Waiting Termination of Testbed Oneshot Execution Workflow
+    if: ${{ github.event.review.state == 'approved' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+        # The testbed execution can be triggered/re-run several times, leaving multiple
+        # check runs with the same name on `develop`. We only care about the most recent
+        # one, so we track the run that this approval just triggered and report only its
+        # outcome (instead of requiring every historical run to be a success).
+        - name: Testbed Oneshot Execution - Waiting cycle
+          env:
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              REPO: ${{ github.repository }}
+              REF: develop
+              CHECK_NAME: Trigger Testbed Oneshot Execution ${{ github.event.pull_request.head.ref }}
+              WAIT_INTERVAL: '20'
+          run: |
+              set -euo pipefail
+
+              # Phase 1: wait until the freshly-triggered run shows up (queued/in_progress)
+              # and capture its id, so we follow that exact run and ignore older ones.
+              echo "Waiting for a new '${CHECK_NAME}' run to start on ${REF}..."
+              target_id=""
+              while [ -z "$target_id" ]; do
+                target_id=$(gh api "repos/${REPO}/commits/${REF}/check-runs" --paginate \
+                  --jq "[.check_runs[] | select(.name == \"${CHECK_NAME}\" and .status != \"completed\")] | sort_by(.started_at) | last | .id // empty")
+                if [ -z "$target_id" ]; then
+                  echo "  no in-progress run yet; retrying in ${WAIT_INTERVAL}s..."
+                  sleep "$WAIT_INTERVAL"
+                fi
+              done
+              echo "Tracking check run id=${target_id}"
+
+              # Phase 2: wait for that specific run to complete and report only its conclusion.
+              while true; do
+                run=$(gh api "repos/${REPO}/check-runs/${target_id}")
+                status=$(echo "$run" | jq -r '.status')
+                conclusion=$(echo "$run" | jq -r '.conclusion')
+                echo "  status=${status} conclusion=${conclusion}"
+                if [ "$status" = "completed" ]; then
+                  if [ "$conclusion" = "success" ]; then
+                    echo "Latest testbed run succeeded."
+                    exit 0
+                  fi
+                  echo "Latest testbed run concluded with '${conclusion}'."
+                  exit 1
+                fi
+                sleep "$WAIT_INTERVAL"
+              done

--- a/.github/workflows/oneshot_testbed_workflow_run.yml
+++ b/.github/workflows/oneshot_testbed_workflow_run.yml
@@ -1,0 +1,43 @@
+name: Testbed Oneshot - Multiple Scenarios Test Deployment
+
+# The testbed execution is triggered after the PR approval is validated by `oneshot_testbed_approval.yml`.
+# The action execute a custom action `awx-deploy` to trigger the deployment on Ansible AWX.
+# The action waits for the deployment to complete before reporting the outcome.
+# The success/failure of the deployment is reported back to the PR by the `oneshot_testbed_approval.yml` action.
+# The oakestra-net PR branch is tested against the `develop` branch of the oakestra repository.
+
+on:
+  workflow_run:
+    workflows: ["Testbed Oneshot - Intermediate Approval Check"]
+    types:
+      - requested
+
+jobs:
+  trigger-awx-job:
+    name: Trigger Testbed Oneshot Execution ${{ github.event.workflow_run.head_branch }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./.github/actions/awx-deploy
+
+      - name: Testbed Oneshot Execution ${{ github.event.workflow_run.head_branch }}
+        uses: ./.github/actions/awx-deploy
+        env:
+          NODE_TLS_REJECT_UNAUTHORIZED: '0'
+        with:
+          AWX_URL: ${{ secrets.TOWER_HOST }}
+          AWX_TOKEN: ${{ secrets.TOWER_TOKEN }}
+          AWX_TEMPLATE_ID: 18 # Job Workflow Template ID for Oneshot Testbed Execution
+          PR_NET_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PR_NET_COMMIT: HEAD
+          PR_USER: ${{ github.event.workflow_run.head_commit.author.name }}
+          OAK_BRANCH: develop
+          OAK_COMMIT: HEAD


### PR DESCRIPTION
Fixes #246 

This pull request introduces a new GitHub Actions workflow to automate the deployment and testing of PRs using Ansible AWX. It adds a two-step process: first, checking for PR approval and waiting for the corresponding testbed deployment to complete; second, triggering and monitoring the AWX deployment itself. The implementation includes a custom action that interacts with AWX and reports the outcome back to the PR. The main changes are as follows:

**Workflow Orchestration:**

* Added `.github/workflows/oneshot_testbed_approval.yml` to monitor PR approvals, wait for the corresponding testbed deployment to start, and report its outcome by tracking the latest relevant check run.
* Added `.github/workflows/oneshot_testbed_workflow_run.yml` to trigger the AWX deployment workflow upon approval, using the custom `awx-deploy` action, and passing the relevant PR and branch information.

**Custom AWX Deployment Action:**

* Introduced `.github/actions/awx-deploy/` containing:
  - [`action.yml`](diffhunk://#diff-8a72fa036a24c3d3bc39ae83ff3cd72afb7cfc0729623c7a6e90d60d5c8fa4f8R1-R34): Defines the action interface, inputs, and execution environment for triggering AWX deployments.
  - [`index.js`](diffhunk://#diff-5cb1c94846830255cc4b9e171bff4b472c09a6b63f30c267cfdcde7b1f6478a0R1-R76): Implements the logic to trigger an AWX workflow job, poll for its completion, handle success/failure, and report status.
  - [`package.json`](diffhunk://#diff-87a5d985fa1de7c2659587ad12247dffbbf138473ac7d3d0facae7573e7c295fR1-R17): Specifies dependencies (`axios`, `@actions/core`, `ssl-root-cas`) and action metadata.